### PR TITLE
chore: add .gitignore for Python and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python byte-compiled / cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Python packaging
+*.egg-info/
+*.egg
+build/
+dist/
+
+# Test / coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editor swap / OS junk
+*.swp
+*~
+.DS_Store


### PR DESCRIPTION
## Summary

Adds a focused `.gitignore` so Python build artifacts (`__pycache__/`, `*.pyc`, `*.egg-info/`, etc.) and standard editor/OS junk no longer accumulate as untracked files in the working tree.

Closes #12

The immediate trigger was four stray `bag_analysis/.../__pycache__/` directories accumulating in the main checkout, which caused the workspace's `make sync` to skip this repo with "Uncommitted changes detected" even though the changes were just regenerable build noise.

Covers:

- Python byte-compiled / cache: `__pycache__/`, `*.py[cod]`, `*$py.class`
- Python packaging: `*.egg-info/`, `*.egg`, `build/`, `dist/`
- Test / coverage: `.pytest_cache/`, `.coverage`, `htmlcov/`
- Editor / OS noise: `*.swp`, `*~`, `.DS_Store`

Verified that no currently-tracked files in the repo match any of the new patterns, so nothing gets accidentally hidden.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
