### PR TITLE
ci: add build+test workflow (closes #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+# CI for marine_tools. See ADR-0004/0005 (enforcement hierarchy) in the
+# workspace repo for the rationale behind the build+test+lint gate: a
+# framework-native per-repo check for fast feedback, backed by the workspace
+# `make build` integration gate.
+
+name: CI
+
+on:
+  push:
+    branches: [jazzy]
+  pull_request:
+    branches: [jazzy]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    container:
+      image: ros:jazzy-ros-core
+
+    steps:
+      - name: Update apt
+        run: apt-get update
+
+      - name: Install ros dev tools + git
+        run: DEBIAN_FRONTEND=noninteractive apt-get -y install ros-dev-tools git
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Init rosdep
+        run: |
+          if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
+            rosdep init
+          fi
+
+      - name: Update rosdep
+        run: rosdep update
+
+      - name: Create workspace
+        run: mkdir -p ../ws/src && ln -s "$GITHUB_WORKSPACE" ../ws/src/marine_tools
+
+      # marine_tools packages depend on three interface packages that are source
+      # siblings, not rosdep/binary packages: marine_interfaces
+      # (unh_marine_autonomy), udp_bridge_interfaces (udp_bridge), and
+      # marine_radar_control_msgs (unh_marine_radar — used by garmin_sidescan).
+      # Clone each and prune to just the interface package so rosdep/colcon stay
+      # light (the parent repos carry heavy nav2/mavros/radar packages we don't
+      # need). The workspace `make build` is the full integration gate; this
+      # per-repo CI is the lighter-weight check.
+      - name: Clone source-sibling interface packages
+        run: |
+          set -e
+          clone_prune() {  # <repo-url> <branch> <dir> <keep-package-dir>
+            git clone --depth 1 -b "$2" "$1" "../ws/src/$3"
+            ( cd "../ws/src/$3" && \
+              find . -maxdepth 1 -mindepth 1 -type d \
+                ! -name "$4" ! -name '.git' -exec rm -rf {} + )
+          }
+          clone_prune https://github.com/rolker/unh_marine_autonomy.git jazzy \
+            unh_marine_autonomy marine_interfaces
+          clone_prune https://github.com/rolker/udp_bridge.git jazzy \
+            udp_bridge udp_bridge_interfaces
+          clone_prune https://github.com/rolker/unh_marine_radar.git jazzy \
+            unh_marine_radar marine_radar_control_msgs
+
+      - name: Install ROS dependencies
+        working-directory: ../ws
+        run: >
+          DEBIAN_FRONTEND=noninteractive
+          rosdep install --from-paths src --ignore-src -r -y
+
+      - name: Build
+        working-directory: ../ws
+        run: >
+          bash -c 'source /opt/ros/jazzy/setup.bash &&
+          colcon build --cmake-args -DBUILD_TESTING=ON'
+
+      # Test only this repo's packages (not the cloned interface siblings). The
+      # package list is derived from the repo path so newly added packages are
+      # covered automatically.
+      - name: Test
+        working-directory: ../ws
+        run: >
+          bash -c 'source /opt/ros/jazzy/setup.bash &&
+          source install/setup.bash &&
+          PKGS=$(colcon list --names-only --base-paths "$GITHUB_WORKSPACE" | tr "\n" " ") &&
+          echo "Testing packages: $PKGS" &&
+          colcon test --packages-select $PKGS
+          --event-handlers console_direct+
+          --return-code-on-test-failure'
+
+      - name: Test results
+        working-directory: ../ws
+        run: >
+          bash -c 'source /opt/ros/jazzy/setup.bash &&
+          colcon test-result --verbose'
+        if: always()

--- a/bag_analysis/test/test_power_plot.py
+++ b/bag_analysis/test/test_power_plot.py
@@ -233,7 +233,8 @@ def test_voltage_only_summary_uses_full_bag_label_when_window_missing(tmp_path):
 
 
 def test_power_ignores_rcout_outside_battery_time_range(tmp_path):
-    """rcout that doesn't overlap battery in time must not classify samples as idle.
+    """
+    Reject rcout that doesn't overlap battery in time from idle classification.
 
     Pre-fix, merge_asof(..., direction='nearest') with no tolerance would
     happily inherit a PWM value from a row arbitrarily far away. With the

--- a/bag_analysis/test/test_sqlite_writer_append.py
+++ b/bag_analysis/test/test_sqlite_writer_append.py
@@ -1,4 +1,5 @@
-"""Tests for SqliteBagWriter --append namespace-fallback warning.
+"""
+Tests for SqliteBagWriter --append namespace-fallback warning.
 
 When --append targets a DB that has no stored robot_namespace and the
 caller doesn't pass --robot-namespace, the writer silently defaults to
@@ -7,6 +8,7 @@ topic-table mappings; the writer must surface that loudly so reports
 generated from the DB don't look authoritative when they're wrong.
 """
 
+import contextlib
 import json
 import logging
 import sqlite3
@@ -15,7 +17,8 @@ from bag_analysis.sqlite_writer import SqliteBagWriter
 
 
 def _make_legacy_compatible_db(db_path, *, with_namespace: bool):
-    """Build a minimal DB with the schema --append expects to find.
+    """
+    Build a minimal DB with the schema --append expects to find.
 
     Includes `_bags` (the marker that distinguishes new vs pre-multi-bag
     schema), `_bag_meta`, and an empty `_topic_index`. If
@@ -44,13 +47,49 @@ def _make_legacy_compatible_db(db_path, *, with_namespace: bool):
     conn.close()
 
 
-def test_append_warns_when_namespace_must_be_guessed(tmp_path, caplog):
+class _ListHandler(logging.Handler):
+    """Collect emitted log records into a list (test capture helper)."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@contextlib.contextmanager
+def _capture_warnings(logger_name):
+    """
+    Collect WARNING+ records from `logger_name` via an attached handler.
+
+    Deliberately does not use pytest's ``caplog``: that captures via a handler
+    the pytest logging plugin installs on the *root* logger and relies on the
+    record propagating there. On a minimal install (e.g. CI) that root handler
+    can be absent, so the record falls through to ``logging.lastResort`` and
+    ``caplog`` stays empty — making the warn assertion fail and the "silent"
+    assertions pass vacuously. Attaching our own handler to the target logger
+    is deterministic across environments.
+    """
+    logger = logging.getLogger(logger_name)
+    handler = _ListHandler()
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        yield handler.records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+
+def test_append_warns_when_namespace_must_be_guessed(tmp_path):
     """No stored namespace + no --robot-namespace → loud warning, 'bizzy' fallback."""
     db_path = tmp_path / 'extract.sqlite'
     _make_legacy_compatible_db(db_path, with_namespace=False)
 
     writer = SqliteBagWriter(db_path, append=True)
-    with caplog.at_level(logging.WARNING, logger='bag_analysis.sqlite_writer'):
+    with _capture_warnings('bag_analysis.sqlite_writer') as records:
         meta = writer.finalize(
             source_bag_path=tmp_path / 'fake.bag',
             start_ns=1_700_000_060_000_000_000,
@@ -59,18 +98,18 @@ def test_append_warns_when_namespace_must_be_guessed(tmp_path, caplog):
         )
 
     assert meta['robot_namespace'] == 'bizzy'
-    warning_text = '\n'.join(r.message for r in caplog.records)
+    warning_text = '\n'.join(r.getMessage() for r in records)
     assert 'no stored robot_namespace' in warning_text, warning_text
     assert "defaulting to 'bizzy'" in warning_text, warning_text
 
 
-def test_append_is_silent_when_namespace_explicit(tmp_path, caplog):
+def test_append_is_silent_when_namespace_explicit(tmp_path):
     """--robot-namespace passed → no warning fires (no guess needed)."""
     db_path = tmp_path / 'extract.sqlite'
     _make_legacy_compatible_db(db_path, with_namespace=False)
 
     writer = SqliteBagWriter(db_path, append=True)
-    with caplog.at_level(logging.WARNING, logger='bag_analysis.sqlite_writer'):
+    with _capture_warnings('bag_analysis.sqlite_writer') as records:
         meta = writer.finalize(
             source_bag_path=tmp_path / 'fake.bag',
             start_ns=1_700_000_060_000_000_000,
@@ -80,18 +119,18 @@ def test_append_is_silent_when_namespace_explicit(tmp_path, caplog):
 
     assert meta['robot_namespace'] == 'zebra'
     assert all(
-        'no stored robot_namespace' not in r.message
-        for r in caplog.records
-    ), [r.message for r in caplog.records]
+        'no stored robot_namespace' not in r.getMessage()
+        for r in records
+    ), [r.getMessage() for r in records]
 
 
-def test_append_is_silent_when_namespace_stored(tmp_path, caplog):
+def test_append_is_silent_when_namespace_stored(tmp_path):
     """DB has a stored namespace → no warning fires (no guess needed)."""
     db_path = tmp_path / 'extract.sqlite'
     _make_legacy_compatible_db(db_path, with_namespace=True)
 
     writer = SqliteBagWriter(db_path, append=True)
-    with caplog.at_level(logging.WARNING, logger='bag_analysis.sqlite_writer'):
+    with _capture_warnings('bag_analysis.sqlite_writer') as records:
         meta = writer.finalize(
             source_bag_path=tmp_path / 'fake.bag',
             start_ns=1_700_000_060_000_000_000,
@@ -101,6 +140,6 @@ def test_append_is_silent_when_namespace_stored(tmp_path, caplog):
 
     assert meta['robot_namespace'] == 'zebra'
     assert all(
-        'no stored robot_namespace' not in r.message
-        for r in caplog.records
-    ), [r.message for r in caplog.records]
+        'no stored robot_namespace' not in r.getMessage()
+        for r in records
+    ), [r.getMessage() for r in records]

--- a/sound_speed_bridge/sound_speed_bridge/node.py
+++ b/sound_speed_bridge/sound_speed_bridge/node.py
@@ -21,7 +21,7 @@ from sensor_msgs.msg import FluidPressure, Temperature
 import serial
 
 from .parsers import PARSERS, SoundSpeedReading
-from .sinks import FORMATTERS, decode_template
+from .sinks import decode_template, FORMATTERS
 
 
 class _UdpTarget:

--- a/sound_speed_bridge/sound_speed_bridge/sinks.py
+++ b/sound_speed_bridge/sound_speed_bridge/sinks.py
@@ -111,7 +111,8 @@ def format_template(
 
 
 def decode_template(format_name: str, template: str) -> str:
-    """Decode backslash escapes in a user-supplied template string at startup.
+    r"""
+    Decode backslash escapes in a user-supplied template string at startup.
 
     Validated once at config time so a malformed escape (e.g. ``\\xZZ``) or
     a non-ASCII character raises a clear configuration error instead of

--- a/sound_speed_bridge/test/test_sinks.py
+++ b/sound_speed_bridge/test/test_sinks.py
@@ -89,7 +89,8 @@ def test_passthrough_skips_when_raw_bytes_empty():
 
 
 def test_template_basic_format_with_int_mm_s():
-    r"""Bit-exact int mm/s flows through {value_int_mm_s} unchanged.
+    r"""
+    Bit-exact int mm/s flows through {value_int_mm_s} unchanged.
 
     Templates arrive at the formatter already decoded by the node.
     """


### PR DESCRIPTION
Adds a `.github/workflows/ci.yml` build+test gate, closing #18.

## What it does
- Runs on push + PR to `jazzy` in a `ros:jazzy-ros-core` container.
- `rosdep install` → `colcon build` (`-DBUILD_TESTING=ON`) → `colcon test` → `colcon test-result`.
- Modeled on the sibling repo `marine_perception_tools`; ADR-0004/0005 (per-repo fast-feedback gate, backed by the workspace `make build` integration gate).

## Repo-specific handling
- **Three source siblings** are cloned and each **pruned to just its interface package** (their parent repos carry heavy nav2/mavros/radar packages we don't need):
  - `marine_interfaces` ← `rolker/unh_marine_autonomy`
  - `udp_bridge_interfaces` ← `rolker/udp_bridge`
  - `marine_radar_control_msgs` ← `rolker/unh_marine_radar` (for `garmin_sidescan`, PR #17)
- Heavy deps (`pcl_ros`, `sbg_driver`, `mavros_msgs`, `nav2_msgs`) are all apt-resolvable via rosdep.
- **All packages covered**: the test step derives the package list from the repo path, so it tests `bag_analysis`, `kongsberg_em_bridge`, `marine_tools`, `sound_speed_bridge`, `zda_serial_bridge` today and picks up `garmin_sidescan` automatically once #15/#17 merges — no edit needed.

## Follow-up (maintainer — not in this PR)
After this runs green once, add the `build-and-test` job as a **required status check** on `jazzy`. Changing branch protection is an Ask-First / maintainer action per `AGENTS.md`.

Paired with the same gap in `rolker/rqt_operator_tools` (rolker/rqt_operator_tools#42).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
