### PR TITLE
garmin_sidescan: generic example launch + proxy Windows-service installer (closes #20)

### DIFF
--- a/.agent/work-plans/issue-20/progress.md
+++ b/.agent/work-plans/issue-20/progress.md
@@ -15,8 +15,8 @@ issue: 20
 **CI**: copilot check pass; no build-and-test visible (marine_tools gate #18/#19 may be unmerged)
 
 ### Findings
-- [ ] (valid, Copilot) install_proxy_service.ps1 + tools/README default logs to `C:\project11\logs` — project-specific in a generic repo; use the ProgramData convention (`$env:ProgramData\GarminProxy\logs`) — `garmin_sidescan/tools/install_proxy_service.ps1`, `tools/README.md`
-- [ ] (minor, Copilot) example launch docstring names the downstream `bizzyboat_project11` wrapper; a shared driver shouldn't hardcode a consumer — keep the generic split reference only — `garmin_sidescan/launch/garmin_sidescan.launch.py:10`
+- [x] (valid, Copilot) install_proxy_service.ps1 + tools/README default logs to `C:\project11\logs` — project-specific in a generic repo; use the ProgramData convention (`$env:ProgramData\GarminProxy\logs`) — `garmin_sidescan/tools/install_proxy_service.ps1`, `tools/README.md`
+- [x] (minor, Copilot) example launch docstring names the downstream `bizzyboat_project11` wrapper; a shared driver shouldn't hardcode a consumer — keep the generic split reference only — `garmin_sidescan/launch/garmin_sidescan.launch.py:10`
 
 ### False positives
 - (Copilot, x3) frame_id should default to gcv_sonar per issue #20 — the rename to garmin_sidescan was an explicit user instruction superseding the issue text ("don't call it gcv… most people won't have a clue"); launch arg, node default, and docstring all consistently say garmin_sidescan, so there is no real mismatch. Copilot is enforcing the stale pre-rename contract.

--- a/.agent/work-plans/issue-20/progress.md
+++ b/.agent/work-plans/issue-20/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 20
+---
+
+# Issue #20 — garmin_sidescan: ship a generic example launch (move BizzyBoat specifics out of the driver)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-07 21:29 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #21 at `a998f05`
+**Sources**: 2 Copilot reviews (latest @ `a998f05`)
+**Cross-source confirmations**: 0
+**CI**: copilot check pass; no build-and-test visible (marine_tools gate #18/#19 may be unmerged)
+
+### Findings
+- [ ] (valid, Copilot) install_proxy_service.ps1 + tools/README default logs to `C:\project11\logs` — project-specific in a generic repo; use the ProgramData convention (`$env:ProgramData\GarminProxy\logs`) — `garmin_sidescan/tools/install_proxy_service.ps1`, `tools/README.md`
+- [ ] (minor, Copilot) example launch docstring names the downstream `bizzyboat_project11` wrapper; a shared driver shouldn't hardcode a consumer — keep the generic split reference only — `garmin_sidescan/launch/garmin_sidescan.launch.py:10`
+
+### False positives
+- (Copilot, x3) frame_id should default to gcv_sonar per issue #20 — the rename to garmin_sidescan was an explicit user instruction superseding the issue text ("don't call it gcv… most people won't have a clue"); launch arg, node default, and docstring all consistently say garmin_sidescan, so there is no real mismatch. Copilot is enforcing the stale pre-rename contract.

--- a/garmin_sidescan/README.md
+++ b/garmin_sidescan/README.md
@@ -65,8 +65,8 @@ Published (relative to the node namespace):
 | `state` | `marine_radar_control_msgs/RadarControlSet` | latched operator-control set (CAMP renders it) |
 
 Subscribed:
-- the sound-speed topic (default `/bizzy/sensors/sound_speed/sound_speed`,
-  `marine_interfaces/SoundSpeed`).
+- the sound-speed topic (default `sound_speed`, `marine_interfaces/SoundSpeed`;
+  a platform launch sets the absolute path).
 - `change_state` (`marine_radar_control_msgs/RadarControlValue`) — operator
   control changes (`key`/`value`), same contract as the radar driver.
 
@@ -147,16 +147,23 @@ imagery stream because they are not reliably present there:
 
 ## Run
 
+`garmin_sidescan.launch.py` is a **generic example**: no namespace, neutral
+defaults. Override `gcv_ip` / `iface_ip` / `frame_id` for your host. A platform
+is expected to ship its own wrapper that sets the namespace, frame prefix, and
+the absolute sound-speed topic (the same split `sound_speed_bridge` uses:
+`aml_svs.launch.py` here vs. the boat's `sound_speed_launch.py`); topic paths
+below assume the bare example (node at `/garmin_sidescan`).
+
 ```bash
 ros2 launch garmin_sidescan garmin_sidescan.launch.py \
-    iface_ip:=<host Marine-Network IP>
+    gcv_ip:=<GCV IP> iface_ip:=<host Marine-Network IP>
 
 # transmit control
-ros2 service call /sensors/sidescan/garmin_sidescan/set_transmit \
+ros2 service call /garmin_sidescan/set_transmit \
     std_srvs/srv/SetBool "{data: true}"
 
 # set range
-ros2 param set /sensors/sidescan/garmin_sidescan range_m 12.0
+ros2 param set /garmin_sidescan range_m 12.0
 ```
 
 ## Status / follow-ups

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -136,7 +136,7 @@ class GarminSidescanNode(Node):
         self.declare_parameter('mcast_port', 50220)
         self.declare_parameter('iface_ip', '')                 # local NIC for the join
         self.declare_parameter('filter_src', True)
-        self.declare_parameter('frame_id', 'gcv_sonar')
+        self.declare_parameter('frame_id', 'garmin_sidescan')
 
         # channel map (GCV-20: 0=port 1=stbd 2=down; GCV-10 data: port=[3] stbd=[1])
         self.declare_parameter('port_channels', [0])
@@ -175,8 +175,8 @@ class GarminSidescanNode(Node):
 
         # sound-speed watchdog
         self.declare_parameter('sound_speed_safety_enabled', True)
-        self.declare_parameter('sound_speed_topic',
-                               '/bizzy/sensors/sound_speed/sound_speed')
+        # Generic default; a platform launch sets the absolute topic.
+        self.declare_parameter('sound_speed_topic', 'sound_speed')
         self.declare_parameter('sound_speed_type', 'marine_interfaces/msg/SoundSpeed')
         self.declare_parameter('sound_speed_field', 'sound_speed')
         self.declare_parameter('sv_min', 1400.0)

--- a/garmin_sidescan/launch/garmin_sidescan.launch.py
+++ b/garmin_sidescan/launch/garmin_sidescan.launch.py
@@ -5,9 +5,9 @@ Neutral defaults only: no ROS namespace, ``frame_id`` ``garmin_sidescan``, and t
 node's own safe defaults (transmit OFF at startup, sound-speed interlock on,
 sound-speed topic ``sound_speed``). A platform launch is expected to wrap this
 to set the namespace, frame prefix, the GCV's address, the local multicast
-interface, and the absolute sound-speed topic -- see, e.g.,
-``bizzyboat_project11``'s sidescan wrapper, the same split ``sound_speed_bridge``
-uses (``aml_svs.launch.py`` here vs. the boat's ``sound_speed_launch.py``).
+interface, and the absolute sound-speed topic -- the same example-vs-wrapper
+split ``sound_speed_bridge`` uses (``aml_svs.launch.py`` here vs. a downstream
+platform launch).
 """
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument

--- a/garmin_sidescan/launch/garmin_sidescan.launch.py
+++ b/garmin_sidescan/launch/garmin_sidescan.launch.py
@@ -1,46 +1,46 @@
 """
-Launch the Garmin GCV sidescan driver, namespaced for BizzyBoat.
+Example launch for the Garmin GCV sidescan driver.
 
-Topics land under ``/<namespace>/sensors/sidescan/...`` to match the
-``/<ns>/sensors/<sensor>/...`` convention used by the other sensor bridges.
-The sound-speed watchdog defaults to the BizzyBoat AML SVS topic.
+Neutral defaults only: no ROS namespace, ``frame_id`` ``garmin_sidescan``, and the
+node's own safe defaults (transmit OFF at startup, sound-speed interlock on,
+sound-speed topic ``sound_speed``). A platform launch is expected to wrap this
+to set the namespace, frame prefix, the GCV's address, the local multicast
+interface, and the absolute sound-speed topic -- see, e.g.,
+``bizzyboat_project11``'s sidescan wrapper, the same split ``sound_speed_bridge``
+uses (``aml_svs.launch.py`` here vs. the boat's ``sound_speed_launch.py``).
 """
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
-from launch_ros.actions import Node, PushRosNamespace
+from launch_ros.actions import Node
 
 
-def generate_launch_description():
-    frame_prefix = LaunchConfiguration('frame_prefix')
-    gcv_ip = LaunchConfiguration('gcv_ip')
-    iface_ip = LaunchConfiguration('iface_ip')
+def generate_launch_description() -> LaunchDescription:
+    gcv_ip_arg = DeclareLaunchArgument(
+        'gcv_ip', default_value='172.16.3.0',
+        description='GCV unit IP (GCV-10 ships as 172.16.3.196)')
+    iface_ip_arg = DeclareLaunchArgument(
+        'iface_ip', default_value='',
+        description='Local NIC IP to join the imagery multicast on '
+                    '(set on multi-homed hosts)')
+    frame_id_arg = DeclareLaunchArgument(
+        'frame_id', default_value='garmin_sidescan',
+        description='Base frame; channels publish <frame_id>_port / '
+                    '_starboard / _down and are oriented via TF')
 
     return LaunchDescription([
-        DeclareLaunchArgument('frame_prefix', default_value='bizzy/'),
-        DeclareLaunchArgument('gcv_ip', default_value='172.16.3.0'),
-        DeclareLaunchArgument(
-            'iface_ip', default_value='',
-            description='Local NIC IP to join the imagery multicast on'),
-
-        GroupAction(actions=[
-            PushRosNamespace('sensors/sidescan'),
-            Node(
-                package='garmin_sidescan',
-                executable='garmin_sidescan',
-                name='garmin_sidescan',
-                parameters=[{
-                    'gcv_ip': gcv_ip,
-                    'iface_ip': iface_ip,
-                    'frame_id': [frame_prefix, 'gcv_sonar'],
-                    # SAFE default: do not transmit on startup.
-                    'transmit_on_startup': False,
-                    'sound_speed_safety_enabled': True,
-                    'sound_speed_topic': '/bizzy/sensors/sound_speed/sound_speed',
-                }],
-                respawn=True,
-                respawn_delay=2.0,
-                emulate_tty=True,
-            ),
-        ]),
+        gcv_ip_arg,
+        iface_ip_arg,
+        frame_id_arg,
+        Node(
+            package='garmin_sidescan',
+            executable='garmin_sidescan',
+            name='garmin_sidescan',
+            output='screen',
+            parameters=[{
+                'gcv_ip': LaunchConfiguration('gcv_ip'),
+                'iface_ip': LaunchConfiguration('iface_ip'),
+                'frame_id': LaunchConfiguration('frame_id'),
+            }],
+        ),
     ])

--- a/garmin_sidescan/tools/README.md
+++ b/garmin_sidescan/tools/README.md
@@ -38,8 +38,8 @@ powershell -ExecutionPolicy Bypass -File .\install_proxy_service.ps1
 This registers a `GarminProxy` service (auto-start at boot, restart on exit) that
 runs `garmin_marine_network_proxy.ps1` with its built-in defaults. Override the
 proxy's network parameters by editing the proxy's `param()` block or passing
-`-ProxyArgs '...'` to the installer. Logs rotate in `C:\project11\logs\` (set
-`-LogDir`).
+`-ProxyArgs '...'` to the installer. Logs rotate in
+`%ProgramData%\GarminProxy\logs\` (set `-LogDir`).
 
 ```powershell
 nssm status  GarminProxy          # SERVICE_RUNNING

--- a/garmin_sidescan/tools/README.md
+++ b/garmin_sidescan/tools/README.md
@@ -1,0 +1,52 @@
+# garmin_sidescan/tools — Marine Network proxy
+
+The Garmin GCV sidescan sits on the Garmin **Marine Network** (172.16.0.0/16). A
+ROS host whose NIC won't link the Garmin PHY can't reach it directly, so run the
+proxy on a host that *is* on the Marine Network and also on the ROS host's LAN
+(e.g. mercat), and the unmodified `garmin_sidescan` driver runs on the ROS host
+(e.g. gabby).
+
+```
+GCV ──Marine Network (172.16.x)──> proxy host ──> ROS-host LAN ──> garmin_sidescan
+     239.254.2.1:50220 imagery                    unicast :50220 imagery
+     TCP :50227 control                           TCP <listen-ip>:50227 control
+```
+
+| File | Purpose |
+|------|---------|
+| `garmin_marine_network_proxy.py` | The relay (stdlib Python). |
+| `garmin_marine_network_proxy.ps1` | Same relay in PowerShell, for a Windows proxy host. |
+| `install_proxy_service.ps1` | Register the `.ps1` proxy as an auto-start Windows service (NSSM). |
+
+On the ROS host, point the driver at the proxy (its `--listen-ip` is the imagery
+source address, so set `gcv_ip` to it):
+
+```bash
+ros2 launch garmin_sidescan garmin_sidescan.launch.py \
+    gcv_ip:=<proxy listen-ip> iface_ip:=<ROS-host NIC>
+```
+
+## Run the proxy as a Windows service (NSSM)
+
+On the proxy host, from an **elevated** PowerShell:
+
+```powershell
+winget install NSSM.NSSM          # or unzip nssm.exe from https://nssm.cc onto PATH
+powershell -ExecutionPolicy Bypass -File .\install_proxy_service.ps1
+```
+
+This registers a `GarminProxy` service (auto-start at boot, restart on exit) that
+runs `garmin_marine_network_proxy.ps1` with its built-in defaults. Override the
+proxy's network parameters by editing the proxy's `param()` block or passing
+`-ProxyArgs '...'` to the installer. Logs rotate in `C:\project11\logs\` (set
+`-LogDir`).
+
+```powershell
+nssm status  GarminProxy          # SERVICE_RUNNING
+nssm restart GarminProxy
+nssm remove  GarminProxy confirm  # uninstall
+```
+
+> The proxy's default parameters (`-GcvIp 172.16.3.0`, `-ListenIp 192.168.20.8`,
+> relay to `192.168.20.5`) are the BizzyBoat/mercat→gabby wiring; change them for
+> a different install.

--- a/garmin_sidescan/tools/install_proxy_service.ps1
+++ b/garmin_sidescan/tools/install_proxy_service.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Install garmin_marine_network_proxy.ps1 as a Windows service via NSSM.
+
+.DESCRIPTION
+    Registers the proxy (next to this script) as an auto-start Windows service so
+    the GCV -> ROS-host relay runs unattended and survives reboots. The proxy's
+    own defaults carry the network wiring (edit the proxy, or pass args via
+    $ProxyArgs below, if they differ from your install).
+
+    Run from an elevated (Administrator) PowerShell. Re-running reinstalls cleanly.
+
+.PARAMETER Nssm
+    Path to nssm.exe (default: 'nssm' on PATH). Install NSSM first, e.g.
+    `winget install NSSM.NSSM` or unzip from https://nssm.cc and add to PATH.
+
+.PARAMETER ProxyScript
+    Path to garmin_marine_network_proxy.ps1 (default: the copy beside this script).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\install_proxy_service.ps1
+#>
+param(
+    [string] $Nssm        = 'nssm',
+    [string] $ServiceName = 'GarminProxy',
+    [string] $ProxyScript = (Join-Path $PSScriptRoot 'garmin_marine_network_proxy.ps1'),
+    [string] $ProxyArgs   = '',
+    [string] $LogDir      = 'C:\project11\logs'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- preconditions ---------------------------------------------------------- #
+$admin = ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $admin) {
+    throw 'Run this from an elevated (Administrator) PowerShell.'
+}
+if (-not (Get-Command $Nssm -ErrorAction SilentlyContinue)) {
+    throw "nssm not found ('$Nssm'). Install it (winget install NSSM.NSSM) or pass -Nssm <path>."
+}
+if (-not (Test-Path $ProxyScript)) {
+    throw "Proxy script not found: $ProxyScript"
+}
+
+$powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+# -File must come last on the powershell command line.
+$appParams = "-NoProfile -ExecutionPolicy Bypass -File `"$ProxyScript`""
+if ($ProxyArgs) { $appParams += " $ProxyArgs" }
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+# --- reinstall cleanly ------------------------------------------------------ #
+if (& $Nssm status $ServiceName 2>$null) {
+    Write-Host "Existing '$ServiceName' service found; removing first..."
+    & $Nssm stop   $ServiceName 2>$null | Out-Null
+    & $Nssm remove $ServiceName confirm | Out-Null
+}
+
+Write-Host "Installing service '$ServiceName'..."
+& $Nssm install $ServiceName $powershell $appParams
+
+# Run from the proxy's dir; auto-start at boot; restart on any exit.
+& $Nssm set $ServiceName AppDirectory   (Split-Path $ProxyScript)
+& $Nssm set $ServiceName Start          SERVICE_AUTO_START
+& $Nssm set $ServiceName AppExit Default Restart
+& $Nssm set $ServiceName AppRestartDelay 2000
+& $Nssm set $ServiceName AppStdout      (Join-Path $LogDir 'garmin_proxy.out.log')
+& $Nssm set $ServiceName AppStderr      (Join-Path $LogDir 'garmin_proxy.err.log')
+& $Nssm set $ServiceName AppRotateFiles 1
+& $Nssm set $ServiceName AppRotateBytes 10485760
+& $Nssm set $ServiceName Description `
+    'Relays the Garmin GCV sidescan (Marine Network) to the ROS host for the garmin_sidescan driver.'
+
+Write-Host "Starting '$ServiceName'..."
+& $Nssm start $ServiceName
+& $Nssm status $ServiceName
+Write-Host "Done. Logs: $LogDir\garmin_proxy.*.log"

--- a/garmin_sidescan/tools/install_proxy_service.ps1
+++ b/garmin_sidescan/tools/install_proxy_service.ps1
@@ -25,7 +25,7 @@ param(
     [string] $ServiceName = 'GarminProxy',
     [string] $ProxyScript = (Join-Path $PSScriptRoot 'garmin_marine_network_proxy.ps1'),
     [string] $ProxyArgs   = '',
-    [string] $LogDir      = 'C:\project11\logs'
+    [string] $LogDir      = (Join-Path $env:ProgramData 'GarminProxy\logs')
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary

Two things, both keeping the shared `garmin_sidescan` driver platform-agnostic:

### 1. Generic example launch (the original #20)

The launch file was hardcoded for BizzyBoat. Genericized to a neutral example,
mirroring the `sound_speed_bridge` split (`aml_svs.launch.py` example vs. the
boat's `sound_speed_launch.py` wrapper):

- `garmin_sidescan.launch.py`: `gcv_ip` / `iface_ip` / `frame_id` args,
  `frame_id` default `garmin_sidescan` (no `bizzy/` prefix), no `PushRosNamespace`,
  no `/bizzy/...` sound-speed override; relies on the node's safe defaults.
- `node.py`: `sound_speed_topic` default `/bizzy/...` → generic `sound_speed`.
- Descriptive `frame_id` default `garmin_sidescan`, not the obscure `gcv_sonar`
  (launch arg + node param).
- README updated.

### 2. Proxy Windows-service installer (moved here from the boat repo)

The proxy host (mercat) has *this* repo cloned, so its deployment mechanism ships
beside the proxy — no vendored copy in the boat repo (avoids drift):

- `tools/install_proxy_service.ps1`: register `garmin_marine_network_proxy.ps1`
  as an auto-start Windows service via NSSM (restart on exit, rotating logs);
  `-ProxyScript` defaults to the proxy beside it.
- `tools/README.md`: data path, driver wiring, service install/manage steps.

## Testing

- `colcon build` + `colcon test`: **42 tests pass** (flake8, pep257, decode,
  commands, safety). Launch parses.
- PowerShell can't be syntax-checked on the Linux dev host (no `pwsh`); runs on
  the Windows proxy host. **Untested on Windows** — needs an install pass on mercat.

## Related

- BizzyBoat ROS wiring + recording: rolker/unh_echoboats_project11#234
- TF frames: rolker/ben_description#13

Closes #20.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
