### PR TITLE
Field import: marine_tools (2026-06-09)

### DIFF
--- a/garmin_sidescan/tools/install_proxy_service.ps1
+++ b/garmin_sidescan/tools/install_proxy_service.ps1
@@ -54,7 +54,7 @@ New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 # Gate on Get-Service, not `nssm status`: on a fresh install nssm writes
 # "Can't open service!" to stderr and exits non-zero, which trips
 # $ErrorActionPreference = 'Stop' and aborts before anything is installed.
-if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
+if (Get-Service -Name ([System.Management.Automation.WildcardPattern]::Escape($ServiceName)) -ErrorAction SilentlyContinue) {
     Write-Host "Existing '$ServiceName' service found; removing first..."
     & $Nssm stop   $ServiceName 2>$null | Out-Null
     & $Nssm remove $ServiceName confirm | Out-Null

--- a/garmin_sidescan/tools/install_proxy_service.ps1
+++ b/garmin_sidescan/tools/install_proxy_service.ps1
@@ -51,7 +51,10 @@ if ($ProxyArgs) { $appParams += " $ProxyArgs" }
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 
 # --- reinstall cleanly ------------------------------------------------------ #
-if (& $Nssm status $ServiceName 2>$null) {
+# Gate on Get-Service, not `nssm status`: on a fresh install nssm writes
+# "Can't open service!" to stderr and exits non-zero, which trips
+# $ErrorActionPreference = 'Stop' and aborts before anything is installed.
+if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
     Write-Host "Existing '$ServiceName' service found; removing first..."
     & $Nssm stop   $ServiceName 2>$null | Out-Null
     & $Nssm remove $ServiceName confirm | Out-Null


### PR DESCRIPTION
Imports field change from `gitcloud/jazzy`. Closes #24.

## Commit

- `f48d663` garmin_sidescan: fix proxy installer fresh-install guard

## What

`garmin_sidescan/tools/install_proxy_service.ps1`: the reinstall guard gated on
`nssm status`, which on a *fresh* install writes `Can't open service!` to stderr
and exits non-zero — under `$ErrorActionPreference = 'Stop'` that aborts the
installer before anything is installed. Now gated on
`Get-Service -ErrorAction SilentlyContinue`, so a fresh install skips the
removal block cleanly.

## Pre-review

Clean against the Quality Standard — idempotent, commented, no behavior change
on the existing-service path. No automated test (PowerShell installer, no test
harness in repo); the change is a single guarded conditional.

Non-diverged import: branch created from `gitcloud/jazzy`, no merge with `jazzy`
needed.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
