### PR TITLE
garmin proxy: relay :50050 status + :51000 config to the ROS host (#28)

### DIFF
--- a/garmin_sidescan/.agent/work-plans/issue-28/progress.md
+++ b/garmin_sidescan/.agent/work-plans/issue-28/progress.md
@@ -45,3 +45,22 @@ No open items. Holding merge until a fresh Copilot round at `7b9ba8b` is clean
 
 ### False positives
 - (none)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-10 12:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8, 1M context)
+
+**PR**: #29 at `5a63e95`
+**Sources**: 2 (Copilot R2 @ `5a63e95`, two submissions) + CI rollup
+**Cross-source confirmations**: 0
+**CI**: all-pass (build-and-test SUCCESS)
+
+Fresh Copilot round after the round-1 fixes + the round-2 progress commit.
+
+### Findings
+- [x] (minor, Copilot R2) `--relay-to` help + argparse `description=` still named imagery/control only — updated both to "imagery/status/config" (`proxy.py:210,224`) and the matching `.ps1` `.PARAMETER RelayTo` (`proxy.ps1:53`).
+
+### False positives
+- (Copilot R2) `proxy.py:178` "`logged` initialized to `-1`" — stale re-anchored R1 comment; current `proxy.py:177` is `logged = 0` (fixed last round).
+- (Copilot R2) `progress.md:11` "agent-review artifact, consider removing / gitignore `.agent/`" — intentional per ADR-0013 + the triage-reviews skill, which commit `progress.md` to the owning project repo; consistent with other project repos. Surfaced to Roland as a governance choice (keep vs. gitignore `.agent/work-plans/` in project repos).

--- a/garmin_sidescan/.agent/work-plans/issue-28/progress.md
+++ b/garmin_sidescan/.agent/work-plans/issue-28/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 28
+---
+
+# Issue #28 — garmin proxy: relay :50050 status + :51000 config to ROS host
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-10 11:47 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8, 1M context)
+
+**PR**: #29 at `42a5909`
+**Sources**: 1 (Copilot R1 @ `42a5909`) + CI rollup
+**Cross-source confirmations**: 0
+**CI**: all-pass (build-and-test SUCCESS)
+
+### Findings
+- [x] (minor, Copilot) `_relay_loop` `logged` init `-1` emits one idle "0 pkts" line, contradicting the "only when something moved" comment — init to `0` (`.py` + `.ps1`).
+- [x] (valid, Copilot) `.ps1` `Start-UdpRelay` runspaces never disposed → leak in long-running NSSM service — track the runspace and dispose it in shutdown (matches the control-runspace path).
+- [x] (valid, Copilot) `.ps1` relay loop treats every `SocketException` as a timeout, swallowing real socket errors — discriminate `SocketErrorCode == TimedOut` (heartbeat) and log any other. The `.py` already catches `socket.timeout` narrowly, so this was a `.ps1`-only gap.
+
+### False positives
+- (none)

--- a/garmin_sidescan/.agent/work-plans/issue-28/progress.md
+++ b/garmin_sidescan/.agent/work-plans/issue-28/progress.md
@@ -21,3 +21,27 @@ issue: 28
 
 ### False positives
 - (none)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-10 12:05 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8, 1M context)
+
+**PR**: #29 at `7b9ba8b`
+**Sources**: 1 (Copilot R1 @ `42a5909`, pre-fix) + prior Integrated Review @ `42a5909`
+**Cross-source confirmations**: 0 new
+**CI**: all-pass (build-and-test SUCCESS @ `7b9ba8b`)
+
+Re-triage after pushing the round-1 fixes. No fresh Copilot round has landed at
+the current head; this round verifies the R1 findings against the fixed code.
+
+### Findings
+- (addressed) Copilot R1 #1 idle "0 pkts" log — `logged = 0` confirmed at `proxy.py:177`.
+- (addressed) Copilot R1 #2 aux-runspace leak — `$auxRelays {Ps,Rs}` + `$r.Rs.Dispose()` confirmed at `proxy.ps1:351`.
+- (addressed) Copilot R1 #3 SocketException swallow — `SocketErrorCode == TimedOut` discrimination confirmed at `proxy.ps1:163`.
+
+No open items. Holding merge until a fresh Copilot round at `7b9ba8b` is clean
+(per the wait-for-Copilot rule); the re-review must be re-requested in the web UI.
+
+### False positives
+- (none)

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.ps1
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.ps1
@@ -148,7 +148,7 @@ $udpRelayScript = {
         }
 
         $buf = New-Object byte[] 65535
-        $pkts = 0L; $bytes = 0L; $dropped = 0L; $logged = -1L
+        $pkts = 0L; $bytes = 0L; $dropped = 0L; $logged = 0L
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $srcDesc = if ($SrcFilter) { $SrcFilter } else { 'any-source' }
         Log "${Name}: joined ${Group}:${Port} on ${GarminIfaceIp}; relaying ${srcDesc}"
@@ -158,7 +158,11 @@ $udpRelayScript = {
             try {
                 $n = $rx.ReceiveFrom($buf, [ref]$src)
             } catch [System.Net.Sockets.SocketException] {
-                # ReceiveTimeout -> heartbeat (only when something moved) and continue.
+                # Only the ReceiveTimeout is the heartbeat case; surface any other
+                # socket error (e.g. network down) instead of silently spinning.
+                if ($_.Exception.SocketErrorCode -ne [System.Net.Sockets.SocketError]::TimedOut) {
+                    Log "${Name}: socket error: $($_.Exception.SocketErrorCode)"
+                }
                 if ($sw.Elapsed.TotalSeconds -ge 10 -and $pkts -ne $logged) {
                     Log ("${Name}: {0} pkts / {1:n0} bytes relayed{2}" -f $pkts, $bytes,
                          $(if ($dropped) { " ($dropped dropped)" } else { '' }))
@@ -190,7 +194,7 @@ $udpRelayScript = {
 }
 
 # Spin status (GCV-sourced) and config (any-source) relays in their own runspaces.
-$auxPs = @()
+$auxRelays = @()
 function Start-UdpRelay($name, $group, $port, $srcFilter) {
     $rs = [runspacefactory]::CreateRunspace(); $rs.Open()
     $ps = [powershell]::Create(); $ps.Runspace = $rs
@@ -199,10 +203,11 @@ function Start-UdpRelay($name, $group, $port, $srcFilter) {
         AddArgument($port).AddArgument($ListenIp).AddArgument($RelayTo).
         AddArgument($srcFilter)
     [void]$ps.BeginInvoke()
-    return $ps
+    # Track both so shutdown disposes the runspace too (no leak in the service).
+    return [pscustomobject]@{ Ps = $ps; Rs = $rs }
 }
-if (-not $NoStatus) { $auxPs += (Start-UdpRelay 'status' $StatusGroup $StatusPort $GcvIp) }
-if (-not $NoConfig) { $auxPs += (Start-UdpRelay 'config' $ConfigGroup $ConfigPort '') }
+if (-not $NoStatus) { $auxRelays += (Start-UdpRelay 'status' $StatusGroup $StatusPort $GcvIp) }
+if (-not $NoConfig) { $auxRelays += (Start-UdpRelay 'config' $ConfigGroup $ConfigPort '') }
 
 # --- background: TCP control relay -------------------------------------------
 # Run on its own runspace so the (blocking) accept loop does not stall the
@@ -339,10 +344,11 @@ try {
     try { $controlPs.Stop() } catch {}
     try { $controlPs.Dispose() } catch {}
     try { $controlRunspace.Dispose() } catch {}
-    # Tear down the status/config relay runspaces.
-    foreach ($ps in $auxPs) {
-        try { $ps.Stop() } catch {}
-        try { $ps.Dispose() } catch {}
+    # Tear down the status/config relay runspaces (dispose the runspace too).
+    foreach ($r in $auxRelays) {
+        try { $r.Ps.Stop() } catch {}
+        try { $r.Ps.Dispose() } catch {}
+        try { $r.Rs.Dispose() } catch {}
     }
     Log "stopped."
 }

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.ps1
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.ps1
@@ -9,7 +9,7 @@
     Garmin (here: NIC "Ethernet 2", 172.16.55.235/16), with a second NIC on the
     same LAN as the ROS host (here: "BRIDGE", 192.168.20.8/24, gabby = .5).
 
-    It relays the two channels the garmin_sidescan driver uses, exactly as the
+    It relays the channels the garmin_sidescan driver uses, exactly as the
     driver expects to see them, so the *unmodified* driver runs on gabby:
 
       * Imagery  : GCV UDP multicast 239.254.2.1:50220 (received on the Marine
@@ -18,15 +18,25 @@
                    datagrams' source address is -ListenIp; set the driver's
                    gcv_ip to -ListenIp and its filter_src check passes.
 
+      * Status   : GCV 8e03 multicast 239.254.2.2:50050 (transmit flag + nadir
+                   depth) -> relayed the same way, filtered to the GCV's source.
+                   Disable with -NoStatus.
+
+      * Config   : chartplotter CDP multicast 239.254.2.11:51000 (carries the
+                   active range under auto-range) -> relayed from EVERY source on
+                   the group (it originates at the chartplotter, not the GCV).
+                   Capture-only; the driver does not parse it. Disable -NoConfig.
+
       * Control  : TCP <ListenIp>:50227 (from the driver) -> GCV <GcvIp>:50227.
                    The driver opens one short connection per command frame and
                    serializes them, so the listener handles connections one at a
                    time. Bidirectional, though the GCV does not reply.
 
-    There is NO host->GCV imagery path; the relay is one-way for UDP and
-    on-demand for TCP. Nothing is sent to the GCV except the driver's own
-    control frames, so the sonar's transmit safety (sound-speed watchdog) still
-    lives entirely in the driver on gabby.
+    Every UDP relay is one-way GCV->ROS and the TCP relay is on-demand. Nothing
+    is sent to the GCV except the driver's own control frames, so the sonar's
+    transmit safety (sound-speed watchdog) still lives entirely in the driver on
+    gabby. Status/config are relayed by default so the driver's debug_raw
+    capture records them (and status also feeds the driver's device tx flag).
 
 .PARAMETER GarminIfaceIp
     Local IP of the NIC on the Garmin Marine Network (the multicast-join iface).
@@ -69,7 +79,13 @@ param(
     [int]      $ImageryPort   = 50220,
     [string]   $ListenIp      = '192.168.20.8',    # mercat NIC facing gabby
     [string[]] $RelayTo       = @('192.168.20.5'), # gabby (ROS host)
-    [switch]   $ReMulticast
+    [switch]   $ReMulticast,
+    [string]   $StatusGroup   = '239.254.2.2',     # GCV 8e03 status (tx + depth)
+    [int]      $StatusPort    = 50050,
+    [switch]   $NoStatus,
+    [string]   $ConfigGroup   = '239.254.2.11',    # chartplotter CDP config (range)
+    [int]      $ConfigPort    = 51000,
+    [switch]   $NoConfig
 )
 
 $ErrorActionPreference = 'Stop'
@@ -82,9 +98,111 @@ function Log([string]$msg) {
 
 Log "Garmin Marine Network proxy"
 Log "  imagery : mcast ${McastGroup}:${ImageryPort} on ${GarminIfaceIp}  ->  unicast ${ImageryPort} to $($RelayTo -join ', ')$(if($ReMulticast){' (+ re-multicast)'})"
+if (-not $NoStatus) {
+    Log "  status  : mcast ${StatusGroup}:${StatusPort}  ->  unicast ${StatusPort} to $($RelayTo -join ', ')"
+}
+if (-not $NoConfig) {
+    Log "  config  : mcast ${ConfigGroup}:${ConfigPort}  ->  unicast ${ConfigPort} to $($RelayTo -join ', ')"
+}
 Log "  control : tcp ${ListenIp}:${ControlPort}  ->  ${GcvIp}:${ControlPort}"
 Log "  drive gabby with:  gcv_ip:=${ListenIp}  iface_ip:=<gabby LAN IP>"
 Log "  Ctrl+C to stop."
+
+# --- generic UDP relay (status/config): mcast <group>:<port> -> unicast -------
+# Mirrors the imagery loop below but parameterised; runs in its own runspace.
+# $SrcFilter = a GCV IP to accept only its datagrams, or '' to relay every
+# source (the CDP config originates at the chartplotter, not the GCV).
+$udpRelayScript = {
+    param($Name, $GarminIfaceIp, $Group, $Port, $ListenIp, $RelayTo, $SrcFilter)
+
+    function Log([string]$msg) {
+        [Console]::WriteLine(('{0:HH:mm:ss}  {1}' -f [DateTime]::Now, $msg))
+    }
+
+    $rx = $null; $tx = $null
+    try {
+        $rx = [System.Net.Sockets.Socket]::new(
+            [System.Net.Sockets.AddressFamily]::InterNetwork,
+            [System.Net.Sockets.SocketType]::Dgram,
+            [System.Net.Sockets.ProtocolType]::Udp)
+        $rx.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket,
+                            [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)
+        $rx.Bind([System.Net.IPEndPoint]::new([System.Net.IPAddress]::Any, $Port))
+        $mreq = [System.Net.Sockets.MulticastOption]::new(
+            [System.Net.IPAddress]::Parse($Group),
+            [System.Net.IPAddress]::Parse($GarminIfaceIp))
+        $rx.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::IP,
+                            [System.Net.Sockets.SocketOptionName]::AddMembership, $mreq)
+        $rx.ReceiveTimeout = 1000
+
+        # Bind tx to ListenIp so forwarded datagrams' SOURCE is ListenIp.
+        $tx = [System.Net.Sockets.Socket]::new(
+            [System.Net.Sockets.AddressFamily]::InterNetwork,
+            [System.Net.Sockets.SocketType]::Dgram,
+            [System.Net.Sockets.ProtocolType]::Udp)
+        $tx.Bind([System.Net.IPEndPoint]::new([System.Net.IPAddress]::Parse($ListenIp), 0))
+
+        $targets = [System.Collections.Generic.List[System.Net.EndPoint]]::new()
+        foreach ($h in $RelayTo) {
+            $targets.Add([System.Net.IPEndPoint]::new([System.Net.IPAddress]::Parse($h), $Port))
+        }
+
+        $buf = New-Object byte[] 65535
+        $pkts = 0L; $bytes = 0L; $dropped = 0L; $logged = -1L
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $srcDesc = if ($SrcFilter) { $SrcFilter } else { 'any-source' }
+        Log "${Name}: joined ${Group}:${Port} on ${GarminIfaceIp}; relaying ${srcDesc}"
+
+        while ($true) {
+            [System.Net.EndPoint]$src = [System.Net.IPEndPoint]::new([System.Net.IPAddress]::Any, 0)
+            try {
+                $n = $rx.ReceiveFrom($buf, [ref]$src)
+            } catch [System.Net.Sockets.SocketException] {
+                # ReceiveTimeout -> heartbeat (only when something moved) and continue.
+                if ($sw.Elapsed.TotalSeconds -ge 10 -and $pkts -ne $logged) {
+                    Log ("${Name}: {0} pkts / {1:n0} bytes relayed{2}" -f $pkts, $bytes,
+                         $(if ($dropped) { " ($dropped dropped)" } else { '' }))
+                    $logged = $pkts; $sw.Restart()
+                }
+                continue
+            }
+            if ($SrcFilter -and (([System.Net.IPEndPoint]$src).Address.ToString() -ne $SrcFilter)) {
+                continue
+            }
+            foreach ($t in $targets) {
+                try {
+                    [void]$tx.SendTo($buf, 0, $n, [System.Net.Sockets.SocketFlags]::None, $t)
+                } catch {
+                    $dropped++
+                }
+            }
+            $pkts++; $bytes += $n
+            if ($sw.Elapsed.TotalSeconds -ge 10 -and $pkts -ne $logged) {
+                Log ("${Name}: {0} pkts / {1:n0} bytes relayed{2}" -f $pkts, $bytes,
+                     $(if ($dropped) { " ($dropped dropped)" } else { '' }))
+                $logged = $pkts; $sw.Restart()
+            }
+        }
+    } finally {
+        if ($rx) { $rx.Close() }
+        if ($tx) { $tx.Close() }
+    }
+}
+
+# Spin status (GCV-sourced) and config (any-source) relays in their own runspaces.
+$auxPs = @()
+function Start-UdpRelay($name, $group, $port, $srcFilter) {
+    $rs = [runspacefactory]::CreateRunspace(); $rs.Open()
+    $ps = [powershell]::Create(); $ps.Runspace = $rs
+    [void]$ps.AddScript($udpRelayScript).
+        AddArgument($name).AddArgument($GarminIfaceIp).AddArgument($group).
+        AddArgument($port).AddArgument($ListenIp).AddArgument($RelayTo).
+        AddArgument($srcFilter)
+    [void]$ps.BeginInvoke()
+    return $ps
+}
+if (-not $NoStatus) { $auxPs += (Start-UdpRelay 'status' $StatusGroup $StatusPort $GcvIp) }
+if (-not $NoConfig) { $auxPs += (Start-UdpRelay 'config' $ConfigGroup $ConfigPort '') }
 
 # --- background: TCP control relay -------------------------------------------
 # Run on its own runspace so the (blocking) accept loop does not stall the
@@ -221,5 +339,10 @@ try {
     try { $controlPs.Stop() } catch {}
     try { $controlPs.Dispose() } catch {}
     try { $controlRunspace.Dispose() } catch {}
+    # Tear down the status/config relay runspaces.
+    foreach ($ps in $auxPs) {
+        try { $ps.Stop() } catch {}
+        try { $ps.Dispose() } catch {}
+    }
     Log "stopped."
 }

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.ps1
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.ps1
@@ -50,7 +50,7 @@
     THIS value.
 
 .PARAMETER RelayTo
-    One or more ROS-host IPs to forward imagery to (default: gabby).
+    One or more ROS-host IPs to forward imagery/status/config to (default: gabby).
 
 .PARAMETER ReMulticast
     Also re-emit imagery as multicast on the ListenIp side (in addition to the

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.py
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.py
@@ -8,7 +8,7 @@ PHY directly. Run this on a host that DOES link the Garmin (here: mercat's
 "Ethernet 2", 172.16.55.235/16) and also has a NIC on the ROS host's LAN
 (here: "BRIDGE", 192.168.20.8/24, gabby = 192.168.20.5).
 
-It relays the two channels the ``garmin_sidescan`` driver uses, exactly as the
+It relays the channels the ``garmin_sidescan`` driver uses, exactly as the
 driver expects them, so the *unmodified* driver runs on gabby:
 
 * **Imagery** - GCV UDP multicast ``239.254.2.1:50220`` (received on the Marine
@@ -18,13 +18,24 @@ driver expects them, so the *unmodified* driver runs on gabby:
   its ``filter_src`` check passes. (``--re-multicast`` additionally re-emits the
   group on the ROS-host LAN, for hosts that genuinely join it there.)
 
+* **Status** - GCV ``8e03`` multicast ``239.254.2.2:50050`` (transmit flag +
+  nadir depth) is relayed the same way, filtered to the GCV's own source.
+  Disable with ``--no-status``.
+
+* **Config** - chartplotter CDP multicast ``239.254.2.11:51000`` (carries the
+  active range under auto-range) is relayed from *every* source on the group --
+  it originates at the chartplotter, not the GCV. Capture-only; the driver does
+  not parse it. Disable with ``--no-config``.
+
 * **Control** - TCP ``<listen-ip>:50227`` from the driver is forwarded to the
   GCV at ``<gcv-ip>:50227``. The driver opens one short connection per command
   and serializes them; connections are handled on a thread each regardless.
 
-There is no host->GCV imagery path (UDP relay is one-way) and nothing reaches
-the GCV except the driver's own control frames, so the sonar's transmit safety
-(the sound-speed watchdog) stays entirely in the driver on gabby.
+Every UDP relay is one-way GCV->ROS and nothing reaches the GCV except the
+driver's own control frames, so the sonar's transmit safety (the sound-speed
+watchdog) stays entirely in the driver on gabby. The status/config streams are
+relayed by default so the driver's ``debug_raw`` capture records them; relaying
+status also feeds the driver's (otherwise-starved) device transmit-flag path.
 
 On gabby, run the stock driver pointed at the proxy::
 
@@ -115,10 +126,10 @@ def _control_loop(listen_ip, control_port, gcv_ip, stop):
 
 
 # --------------------------------------------------------------------------- #
-# Imagery: multicast 239.254.2.1:port (Marine Network)  ->  unicast to ROS host
+# UDP relay: multicast <group>:<port> (Marine Network)  ->  unicast to ROS host
 # --------------------------------------------------------------------------- #
 def _open_mcast_rx(iface_ip, group, port):
-    """Join the GCV imagery group on a specific local interface."""
+    """Join a GCV multicast group on a specific local interface."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(('', port))
@@ -128,26 +139,42 @@ def _open_mcast_rx(iface_ip, group, port):
     return sock
 
 
-def _imagery_loop(args, stop):
-    rx = _open_mcast_rx(args.garmin_iface_ip, args.mcast_group, args.imagery_port)
+def _relay_loop(args, stop, name, group, port, src_filter,
+                re_multicast=False, log_period=2.0):
+    """
+    Relay one GCV multicast stream to the ROS host as unicast.
+
+    Receive ``group:port`` on the Marine-Network NIC and forward each datagram
+    to every ``--relay-to`` host on the same port, with the send socket bound to
+    ``--listen-ip`` so the source address matches the driver's ``gcv_ip``.  When
+    ``src_filter`` is an IP, only datagrams from that source are relayed (imagery
+    and the ``8e03`` status come from the GCV itself, so other devices sharing
+    the group are ignored); pass ``None`` to relay every source -- the CDP config
+    originates at the chartplotter, whose IP is not ours to assume.  This stays a
+    one-way GCV->ROS path: nothing it relays can reach the GCV.  ``re_multicast``
+    additionally re-emits the group on the ROS-host LAN for hosts that genuinely
+    join it there.
+    """
+    rx = _open_mcast_rx(args.garmin_iface_ip, group, port)
 
     # Bind tx to listen_ip so forwarded datagrams' SOURCE is listen_ip; the
     # driver's filter_src compares the source against gcv_ip (= listen_ip).
     tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     tx.bind((args.listen_ip, 0))
 
-    targets = [(h, args.imagery_port) for h in args.relay_to]
-    if args.re_multicast:
+    targets = [(h, port) for h in args.relay_to]
+    if re_multicast:
         tx.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
                       socket.inet_aton(args.listen_ip))
         tx.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
-        targets.append((args.mcast_group, args.imagery_port))
+        targets.append((group, port))
 
-    log(f'imagery: joined {args.mcast_group}:{args.imagery_port} on '
-        f'{args.garmin_iface_ip}; relaying {args.gcv_ip} -> '
+    log(f'{name}: joined {group}:{port} on {args.garmin_iface_ip}; relaying '
+        f'{src_filter or "any-source"} -> '
         f'{", ".join(f"{h}:{p}" for h, p in targets)}')
 
     pkts = bytes_ = dropped = 0
+    logged = -1
     last = time.monotonic()
     try:
         while not stop.is_set():
@@ -156,8 +183,7 @@ def _imagery_loop(args, stop):
             except socket.timeout:
                 payload = None
             else:
-                # Only relay the GCV's own imagery (ignore other group traffic).
-                if src[0] == args.gcv_ip:
+                if src_filter is None or src[0] == src_filter:
                     for tgt in targets:
                         try:
                             tx.sendto(payload, tgt)
@@ -166,9 +192,12 @@ def _imagery_loop(args, stop):
                     pkts += 1
                     bytes_ += len(payload)
             now = time.monotonic()
-            if now - last >= 2.0:
+            # Report throughput periodically, but only when something moved, so
+            # the low-rate status/config streams don't spam idle lines.
+            if now - last >= log_period and pkts != logged:
                 extra = f' ({dropped} dropped)' if dropped else ''
-                log(f'imagery: {pkts} pkts / {bytes_:,} bytes relayed{extra}')
+                log(f'{name}: {pkts} pkts / {bytes_:,} bytes relayed{extra}')
+                logged = pkts
                 last = now
     finally:
         rx.close()
@@ -176,6 +205,7 @@ def _imagery_loop(args, stop):
 
 
 def main():
+    """Parse arguments and run the imagery/status/config/control relays."""
     parser = argparse.ArgumentParser(
         description='Garmin Marine Network proxy: relay GCV imagery + control '
                     'to a ROS host that cannot link the Garmin NIC.',
@@ -194,6 +224,20 @@ def main():
                         help='ROS host IP(s) to forward imagery to')
     parser.add_argument('--re-multicast', action='store_true',
                         help='also re-emit imagery as multicast on the ROS-host LAN')
+    # Status + config streams: relayed by default so the driver's debug_raw
+    # capture sees them (they carry the device transmit flag / depth and the
+    # chartplotter's CDP range config). Disable per-stream if a capture-only or
+    # control-untouched run is wanted.
+    parser.add_argument('--status-group', default='239.254.2.2',
+                        help='GCV 8e03 status multicast group (tx flag + depth)')
+    parser.add_argument('--status-port', type=int, default=50050)
+    parser.add_argument('--no-status', action='store_true',
+                        help='do not relay the :50050 status stream')
+    parser.add_argument('--config-group', default='239.254.2.11',
+                        help='chartplotter CDP config multicast group (range)')
+    parser.add_argument('--config-port', type=int, default=51000)
+    parser.add_argument('--no-config', action='store_true',
+                        help='do not relay the :51000 config stream')
     args = parser.parse_args()
 
     log('Garmin Marine Network proxy')
@@ -201,19 +245,40 @@ def main():
         f'{args.garmin_iface_ip}  ->  unicast {args.imagery_port} to '
         f'{", ".join(args.relay_to)}'
         + (' (+ re-multicast)' if args.re_multicast else ''))
+    if not args.no_status:
+        log(f'  status  : mcast {args.status_group}:{args.status_port}  ->  '
+            f'unicast {args.status_port} to {", ".join(args.relay_to)}')
+    if not args.no_config:
+        log(f'  config  : mcast {args.config_group}:{args.config_port}  ->  '
+            f'unicast {args.config_port} to {", ".join(args.relay_to)}')
     log(f'  control : tcp {args.listen_ip}:{args.control_port}  ->  '
         f'{args.gcv_ip}:{args.control_port}')
     log(f'  drive gabby with:  gcv_ip:={args.listen_ip}  iface_ip:=<gabby LAN IP>')
     log('  Ctrl+C to stop.')
 
     stop = threading.Event()
-    ctrl = threading.Thread(
+    threading.Thread(
         target=_control_loop,
         args=(args.listen_ip, args.control_port, args.gcv_ip, stop),
-        daemon=True)
-    ctrl.start()
+        daemon=True).start()
+    # Status comes from the GCV itself (filter to its IP so the chartplotter's
+    # same-magic status frame isn't relayed too); config comes from the
+    # chartplotter, so relay every source on that group.
+    if not args.no_status:
+        threading.Thread(
+            target=_relay_loop, daemon=True,
+            args=(args, stop, 'status', args.status_group, args.status_port,
+                  args.gcv_ip),
+            kwargs={'log_period': 10.0}).start()
+    if not args.no_config:
+        threading.Thread(
+            target=_relay_loop, daemon=True,
+            args=(args, stop, 'config', args.config_group, args.config_port,
+                  None),
+            kwargs={'log_period': 10.0}).start()
     try:
-        _imagery_loop(args, stop)
+        _relay_loop(args, stop, 'imagery', args.mcast_group, args.imagery_port,
+                    args.gcv_ip, re_multicast=args.re_multicast)
     except KeyboardInterrupt:
         pass
     finally:

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.py
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.py
@@ -174,7 +174,7 @@ def _relay_loop(args, stop, name, group, port, src_filter,
         f'{", ".join(f"{h}:{p}" for h, p in targets)}')
 
     pkts = bytes_ = dropped = 0
-    logged = -1
+    logged = 0
     last = time.monotonic()
     try:
         while not stop.is_set():

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.py
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.py
@@ -207,8 +207,8 @@ def _relay_loop(args, stop, name, group, port, src_filter,
 def main():
     """Parse arguments and run the imagery/status/config/control relays."""
     parser = argparse.ArgumentParser(
-        description='Garmin Marine Network proxy: relay GCV imagery + control '
-                    'to a ROS host that cannot link the Garmin NIC.',
+        description='Garmin Marine Network proxy: relay GCV imagery + status + '
+                    'config + control to a ROS host that cannot link the Garmin NIC.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--garmin-iface-ip', default='172.16.55.235',
                         help='local NIC IP on the Garmin Marine Network')
@@ -221,7 +221,7 @@ def main():
                         help='local NIC IP facing the ROS host; set the driver '
                              'gcv_ip to this')
     parser.add_argument('--relay-to', nargs='+', default=['192.168.20.5'],
-                        help='ROS host IP(s) to forward imagery to')
+                        help='ROS host IP(s) to forward imagery/status/config to')
     parser.add_argument('--re-multicast', action='store_true',
                         help='also re-emit imagery as multicast on the ROS-host LAN')
     # Status + config streams: relayed by default so the driver's debug_raw


### PR DESCRIPTION
## Summary

The mercat `garmin_marine_network_proxy` relayed only **imagery** (`:50220`)
and **TCP control** (`:50227`) to gabby. The GCV `8e03` **status** (`:50050`,
transmit flag + nadir depth) and the chartplotter **CDP config** (`:51000`,
which carries the active range under auto-range) are Marine-Network multicast
that gabby can't see, and the proxy didn't forward them — so every 2026-06-08 /
06-09 raw bag recorded **0** status/config messages, and range / sample-rate are
unrecoverable when running passive on the chartplotter's auto-range.

## Change

Generalise the imagery relay into a reusable UDP relay and add two streams
(both `.py` and the `.ps1` that mercat runs as the NSSM service):

- **status `:50050`** — filtered to the GCV's own source, so the chartplotter's
  same-magic (`8e03`) status frame isn't relayed into the driver's status parser.
- **config `:51000`** — relayed from **every** source (it originates at the
  chartplotter, whose IP we shouldn't hardcode). Capture-only; the driver does
  not parse config.

Both default **on** (`--no-status`/`--no-config`, `-NoStatus`/`-NoConfig` to
disable), so the installed service picks them up on restart with no arg change.
Every UDP relay stays **one-way GCV→ROS** — nothing new can reach the GCV, so the
driver's transmit safety is untouched.

## Verification

- Python relay: loopback smoke test — joins a multicast group and forwards the
  datagram to the unicast target. ✓
- `flake8` + `pydocstyle` clean. ✓
- `.ps1` mirrors the (already in-production) imagery loop; `pwsh` isn't available
  on the dev box, so it was written by mirroring rather than executed.

## To actually capture next time (prerequisites, separate)

1. Deploy the updated `.ps1` to mercat (re-run / restart the NSSM service).
2. Launch the driver with `debug_raw:=true`.
3. Record `~/debug/raw_status` **and** `~/debug/raw_config` (the boat
   `sonar_logger` list in `unh_echoboats_project11` currently includes
   `debug/raw_status` — confirm `debug/raw_config` is added too).

## Behavior note

Relaying `:50050` also feeds the driver's existing (currently-starved) device
transmit-flag path. Use `--no-status` for a control-untouched, capture-only first
outing if preferred.

Closes #28 · Part of rolker/unh_echoboats_project11#245 follow-ups · enables the
deferred range/sample-rate work (rolker/marine_tools#26).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
