### PR TITLE
garmin_sidescan: control set volatile + heartbeat so rqt/udp_bridge see it (#30)

### DIFF
--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -281,7 +281,12 @@ class GarminSidescanNode(Node):
         self._pub_diag = self.create_publisher(DiagnosticArray, '/diagnostics', 10)
         self._pub_tx = self.create_publisher(Bool, '~/transmitting', latched)
         self._pub_status = self.create_publisher(String, '~/status', latched)
-        self._pub_state = self.create_publisher(RadarControlSet, '~/state', latched)
+        # Control set: volatile depth-10, NOT latched -- mirrors simrad_halo_radar
+        # (the rqt control panel + udp_bridge are built around the radar's model).
+        # transient_local does not cross the udp_bridge, and a volatile subscriber
+        # never sees a latched sample; the set is instead re-sent on a heartbeat
+        # (see _publish_status) so a late / bridged subscriber always populates.
+        self._pub_state = self.create_publisher(RadarControlSet, '~/state', 10)
 
         self.create_service(SetBool, '~/set_transmit', self._on_set_transmit)
         self.create_subscription(RadarControlValue, '~/change_state',
@@ -849,6 +854,10 @@ class GarminSidescanNode(Node):
             f'sv={self._last_sv_value:.1f} sv_age={age_s} '
             f'pings(port/stbd/down)={self._ping_count["port"]}/'
             f'{self._ping_count["stbd"]}/{self._ping_count["down"]}')))
+        # Heartbeat the control set on the same timer (mirrors the radar's 1 Hz
+        # heartbeat): ~/state is volatile, so a late or udp-bridged subscriber
+        # only ever sees it via this periodic re-publish, not the on-change ones.
+        self._publish_control_set()
 
     def _on_param_set(self, params):
         # Validate the whole batch before applying ANY side effect. rclpy

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -854,9 +854,10 @@ class GarminSidescanNode(Node):
             f'sv={self._last_sv_value:.1f} sv_age={age_s} '
             f'pings(port/stbd/down)={self._ping_count["port"]}/'
             f'{self._ping_count["stbd"]}/{self._ping_count["down"]}')))
-        # Heartbeat the control set on the same timer (mirrors the radar's 1 Hz
-        # heartbeat): ~/state is volatile, so a late or udp-bridged subscriber
-        # only ever sees it via this periodic re-publish, not the on-change ones.
+        # Re-publish the control set on the status timer so a late or udp-bridged
+        # subscriber always populates: ~/state is volatile, so it never sees the
+        # on-change publishes. The radar heartbeats this at 1 Hz; here it rides
+        # the existing 2 s status timer.
         self._publish_control_set()
 
     def _on_param_set(self, params):

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -268,3 +268,19 @@ def test_classify_beam_silent_when_consistent():
     GarminSidescanNode._classify_beam(node, _img_layer(0x0e, ch=0))
     assert node._chan_beamtype == {2: 'down', 0: 'sidescan'}
     assert log.warns == []
+
+
+def test_status_heartbeat_republishes_control_set():
+    # Regression for #30: ~/state is volatile (not latched), so the control set
+    # must be re-published on the periodic status heartbeat -- not only on change
+    # -- or a late / udp-bridged rqt subscriber never populates the control panel.
+    node = _FakeNode()
+    node._transmitting = False
+    node._require_sv = True
+    node._safety_latched = False
+    node._last_sv_value = 1500.0
+    node._ping_count = {'port': 0, 'stbd': 0, 'down': 0}
+    node._sv_age = lambda: None
+    node._pub_status = types.SimpleNamespace(publish=lambda msg: None)
+    GarminSidescanNode._publish_status(node)
+    assert node.publishes == 1


### PR DESCRIPTION
## Summary

Fixes the Garmin sidescan controls not appearing in the `rqt_sonar_waterfall`
control panel (and not crossing the udp_bridge to the operator station).

**Root cause:** the driver published its `RadarControlSet` differently from the
marine-radar driver the rqt panel + udp_bridge are designed around.

| | radar (`simrad_halo_radar`) | sidescan (before) |
|---|---|---|
| `/state` QoS | volatile, depth 10 | **`latched` / transient_local** |
| cadence | **1 Hz heartbeat** | **on-change only** |

- `transient_local` does **not** cross the udp_bridge → operator station saw nothing.
- The rqt panel subscribes **volatile** (matching the radar), so on a direct
  connection it missed the latched sample, and with no heartbeat the panel
  stayed empty.

## Fix (driver only — the rqt plugin correctly matches the radar)

- Publish `~/state` with **volatile depth-10** QoS (drop `latched`), mirroring `simrad_halo_radar`.
- **Re-publish the control set on the existing 2 s status heartbeat**, so a late / udp-bridged subscriber always populates.

The command direction (`~/change_state`, QoS 10 volatile) already matched the radar — unchanged.

## Testing

- New regression test: `_publish_status` re-publishes the control set.
- Full `test_safety.py` suite: **25 passed**. flake8 clean on the changed lines.

Closes #30 · Part of rolker/unh_echoboats_project11#245 follow-ups.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
