### PR TITLE
garmin_sidescan: true per-channel range scale (v2) + nadir depth (v1) from the imagery sub-header

### DIFF
--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -1,0 +1,29 @@
+---
+issue: 35
+---
+
+# Issue #35 — garmin_sidescan: publish per-channel range scale from sub-header v2 (sample_rate currently 0 or wrong under auto-range)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-11 21:12 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (findings addressed in 1c91f34)
+
+**Branch**: feature/issue-35 at `1c91f34`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~600 lines / 11 files, sensor-driver publish path)
+**Must-fix**: 1 | **Suggestions**: 7 (1 Copilot false positive dropped)
+
+### Findings
+- [x] (must-fix) replay tool: --rate <= 0 unvalidated divisor — `tools/replay_debug_raw.py:85` (cross-model: Claude + Copilot)
+- [x] (suggestion) down-look must not take commanded-range fallback (~2x wrong scale) — `garmin_sidescan/node.py` (cross-confirmed: adversarial + governance)
+- [x] (suggestion) nadir max_range should be the ping's own v2, not the side-scan command clamp — `garmin_sidescan/node.py`
+- [x] (suggestion) verify tool: filter RawSonarImage topics by name (M3 pollution) — `tools/verify_range_scale.py`
+- [x] (suggestion) verify tool: anchor window to first raw datagram (portability) — `tools/verify_range_scale.py`
+- [x] (suggestion) verify tool: missing assembler flush — `tools/verify_range_scale.py`
+- [x] (suggestion) tools/README: best-effort QoS flag on topic-echo example — `tools/README.md`
+- [x] (governance) platform follow-up for _nadir URDF frame + nadir_depth recording + freq params — filed rolker/unh_echoboats_project11#254
+- Copilot claim that replay t0 anchors to any topic: false positive (loop continues on non-raw topics before t0 is set)
+
+Verification: 64/64 tests; ament flake8/pep257 clean; end-to-end UDP replay of the 2026-06-10 Cod Rock bag through the real node — consumer recovered port/stbd {47.8, 30.4} m across the auto-range step, down {10.8, 11.2} m, nadir_depth 7.62–7.76 m on the shoal.

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -27,3 +27,23 @@ issue: 35
 - Copilot claim that replay t0 anchors to any topic: false positive (loop continues on non-raw topics before t0 is set)
 
 Verification: 64/64 tests; ament flake8/pep257 clean; end-to-end UDP replay of the 2026-06-10 Cod Rock bag through the real node — consumer recovered port/stbd {47.8, 30.4} m across the auto-range step, down {10.8, 11.2} m, nadir_depth 7.62–7.76 m on the shoal.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-12 00:18 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #36 at `4d7ebfe` (fixes landed in `4a060d8`)
+**Sources**: 4 (Copilot R1 @ `655f779`, R2 @ `c1b72cb`, R3 @ `4d7ebfe`, Local Review (Pre-Push) timeline)
+**Cross-source confirmations**: 1
+**CI**: all-pass (build-and-test, copilot-reviewer)
+
+### Findings
+- [x] (cross-confirmed: Copilot R1+R2+R3; consequence of Local-Review remediation) build_nadir_range docstring said max_range = "configured swath maximum" but caller passes the ping's own v2 — `garmin_sidescan/node.py:92`
+- [x] (valid, Copilot R2+R3) nadir_depth could publish spec-invalid Range (range > max_range) on corrupt-but-parseable v1; now gated 0 < v1 <= v2 + test — `garmin_sidescan/node.py:818`
+- [x] (valid, Copilot R1 x2) verify tool xlabel + --start help said "first bag message"; anchor is first raw datagram — `tools/verify_range_scale.py`
+- [x] (valid, Copilot R2) tools hard-coded echo_layer so GCV-10 bags rendered nothing; now generation-voted like the driver (waterfall had the same unflagged flaw, fixed too) — `tools/verify_range_scale.py`, `tools/sidescan_waterfall.py`
+- [x] (valid, Copilot R3) --source help typo — `tools/sidescan_waterfall.py`
+
+### False positives
+- none — all five distinct findings were real

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -47,3 +47,21 @@ Verification: 64/64 tests; ament flake8/pep257 clean; end-to-end UDP replay of t
 
 ### False positives
 - none — all five distinct findings were real
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-12 00:38 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #36 at `5c03d4b` (Copilot round 4; fixes in this commit)
+**Sources**: 2 (Copilot R4 @ `5c03d4b`, prior Integrated Review timeline)
+**Cross-source confirmations**: 0
+**CI**: all-pass
+
+### Findings
+- [x] (valid, Copilot R4) parse_subheader lacked field3==0 / field6-follows invariant checks; corrupt-but-parseable header could yield bogus scale — `garmin_sidescan/decode.py`
+- [x] (valid, Copilot R4) verify tool picked RadarControlSet topic by type only; now namespace-matched to the driver's ~/state — `tools/verify_range_scale.py`
+- [x] (valid, Copilot R4) O(N*M) nadir attach -> searchsorted — `tools/sidescan_waterfall.py`
+
+### False positives
+- (Copilot R4, x4) re-raised rounds-1-3 comments verbatim (xlabel/--start wording, hard-coded extractor, --source typo) — all fixed in 4a060d8 and present at the reviewed head; cited line numbers point at text that no longer exists

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -65,3 +65,19 @@ Verification: 64/64 tests; ament flake8/pep257 clean; end-to-end UDP replay of t
 
 ### False positives
 - (Copilot R4, x4) re-raised rounds-1-3 comments verbatim (xlabel/--start wording, hard-coded extractor, --source typo) — all fixed in 4a060d8 and present at the reviewed head; cited line numbers point at text that no longer exists
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-12 00:47 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #36 at `710f275` (Copilot round 5; fix in this commit)
+**Sources**: 2 (Copilot R5 @ `710f275`, prior Integrated Review timeline)
+**Cross-source confirmations**: 0
+**CI**: all-pass
+
+### Findings
+- [x] (valid, Copilot R5) round-4 field6 check (tag>>3==6) accepted any 0x30-0x37 byte; now exact-bytes 31 02 3f, bounds-safe, fail-closed; full-bag regression 100% — `garmin_sidescan/decode.py`
+
+### False positives
+- (Copilot R5, x3) re-raised stale comments: verify-tool xlabel/--start wording (fixed in 4a060d8, present at reviewed head) and the field3/field6-missing claim (added in 710f275, the very head it reviewed — only the exact-bytes refinement was new)

--- a/garmin_sidescan/README.md
+++ b/garmin_sidescan/README.md
@@ -55,9 +55,10 @@ Published (relative to the node namespace):
 
 | Topic | Type | Notes |
 |-------|------|-------|
-| `sonar_image_port` | `marine_acoustic_msgs/RawSonarImage` | side-scan port, single beam; `DTYPE_UINT16` (GCV-20, little-endian) / `DTYPE_UINT8` (GCV-10). `rx_angles`/`tx_angles` = `0` (a fixed beam has no steering); side/orientation is carried by the per-channel `frame_id` + TF |
+| `sonar_image_port` | `marine_acoustic_msgs/RawSonarImage` | side-scan port, single beam; `DTYPE_UINT16` (GCV-20, little-endian) / `DTYPE_UINT8` (GCV-10). `rx_angles`/`tx_angles` = `0` (a fixed beam has no steering); side/orientation is carried by the per-channel `frame_id` + TF. `sample_rate` is derived from the ping's **own sub-header display range (v2)** — per channel, tracks hardware auto-range — so a consumer recovers `range = sound_speed·bins/(2·sample_rate)`; falls back to the commanded range, then `sample_rate_hz` (see `decode.derive_sample_rate`) |
 | `sonar_image_starboard` | `marine_acoustic_msgs/RawSonarImage` | side-scan starboard |
-| `sonar_image_down` | `marine_acoustic_msgs/RawSonarImage` | down-look (water-column) beam |
+| `sonar_image_down` | `marine_acoustic_msgs/RawSonarImage` | down-look (water-column) beam; its v2 is the water-column range (≠ the side-scan swath) |
+| `nadir_depth` | `sensor_msgs/Range` | per-ping bottom range from the down-look sub-header **v1** (M3-validated to ~1%); beam axis = `+X` of the dedicated `<frame_id>_nadir` frame (point it down in the URDF). Uncorrected for draft/tide/offsets |
 | `debug/raw` | `std_msgs/UInt8MultiArray` | raw UDP payloads — only when `debug_raw:=true`, for offline re-decode |
 | `transmitting` | `std_msgs/Bool` | latched transmit state |
 | `status` | `std_msgs/String` | latched one-line status |
@@ -132,7 +133,9 @@ imagery stream because they are not reliably present there:
 | `iface_ip` | `''` | local NIC IP for the multicast join (set on multi-homed hosts) |
 | `port_channels` / `stbd_channels` / `down_channels` | `[0]` / `[1]` / `[2]` | GCV-20 map; GCV-10 survey data used port=`[3]`, stbd=`[1]` |
 | `freq_port_hz` / `freq_stbd_hz` / `freq_down_hz` | `0.0` | set per transducer; 0 = unavailable |
-| `sample_rate_hz` | `0.0` | 0 = unavailable |
+| `sample_rate_hz` | `0.0` | last-resort fallback when neither the sub-header v2 nor a commanded range gives a scale; 0 = unavailable |
+| `nadir_frame_id` | `''` | frame for `nadir_depth` (+X down); empty derives `<frame_id>_nadir` |
+| `nadir_beam_width_rad` | `0.0` | `Range.field_of_view` for `nadir_depth` |
 | `transmit_on_startup` | `false` | safe default |
 | `sound_speed_safety_enabled` | `true` | dynamic master switch |
 | `require_sound_speed` | `true` | refuse transmit unless a valid SV is fresh; `false` for bench tests |

--- a/garmin_sidescan/README.md
+++ b/garmin_sidescan/README.md
@@ -145,7 +145,7 @@ imagery stream because they are not reliably present there:
 | `range_m` | `0.0` | >0 commands range (settable at runtime) |
 | `range_min_m` / `range_max_m` | `1.0` / `60.0` | bounds of the range control |
 | `expose_gcv10_controls` | `true` | include TVG / interference controls |
-| `device` | `auto` | `auto` detects GCV-10 vs GCV-20 by the sub-header tag byte (picks the echo extractor); `gcv20`/`gcv10` force it |
+| `device` | `auto` | `auto` detects GCV-10 vs GCV-20 structurally from the render-layer count (picks the echo extractor); `gcv20`/`gcv10` force it |
 | `debug_raw` | `false` | publish raw UDP payloads on `debug/raw` for offline re-decode; settable at runtime |
 
 ## Run

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -20,6 +20,7 @@ decodes and the structural analysis here come from the wet captures below.
 | GCV-10 survey pcap (Dan, `dumpcap_file.pcap`) | imagery, 2 channels (1/3), 20 m commanded range | render-layer model, GCV-10 fixtures, grammar + v2=20.00 m validation |
 | `gcv10_20260605-050008.pcap` (bench) | imagery, 3 channels (0/2/5) | GCV-10 grammar validation; down-look beam byte `0x0d` confirmed on GCV-10 |
 | `gcv20_rangesweep_20260605-024550.pcap` (bucket) | all planes, **operator range sweep 3→15 m in 1 m steps + ramp to 50 m** | v2 = the commanded range (exact integers, staircase matches operator actions); config/status behavior under manual range changes |
+| `gcv20_settings_20260605-031143.pcap` (bucket) | all planes, TVG steps + preset/mode toggles + power-cycle | chartplotter-side stream inventory (§4.7), `cdp_current_preset_tab` record, beam gating |
 | 2026-06-05/09 GCV-20 bench/wet | imagery | GCV-20 echo layer, trailer fix (#26), fixtures |
 | `bag_2026-06-10T15.54.41` | all 4 streams, 20 min, **2 Cod Rock auto-range transitions**, M3 in same bag | sub-header varints (M3-validated), status/config decode, auto-range behavior |
 | `bag_2026-06-11T15.35.08` | all 4 streams, 30 min | independent re-verification sweep: envelope 100%, rates/lengths, d807 channel tag, rare status sub-types |
@@ -291,8 +292,11 @@ keepalives — it relies on the real chartplotter).
 
 ### 4.4 Status — `8e03` (`239.254.2.2:50050`)
 
-Fixed 34 bytes. The stream multiplexes **sub-types**, discriminated by the
-payload byte at **offset 9**. Shared frame:
+Fixed 34 bytes **from the GCV**. (The chartplotter broadcasts its own
+**70-byte** `8e03` variant on the same group — see §4.7; boat-side bags have
+only ever shown the 34-byte GCV frames.) The stream multiplexes
+**sub-types**, discriminated by the payload byte at **offset 9**. Shared
+frame:
 
 | offset | bytes | meaning |
 |-------:|-------|---------|
@@ -348,6 +352,13 @@ bus):
   `2f 08`-tagged LEB128 timestamp. Four record kinds seen
   (`yutl-port/stbd/cntr-port/cntr-stbd-engn-sched`), each carrying nested keys
   `yutl-engn-sched-type`, `stnd-sched`, `opt-sched-1/2/3`.
+- **`e508` event record `cdp_current_preset_tab_v1:<NN>` (59/61 B)** —
+  broadcast only when the chartplotter's active preset tab changes (which is
+  why steady-state captures never show it). The 06-05 settings capture shows
+  tab `:48`↔`:49` switches correlating exactly with **which beams stream**
+  (all three ↔ down-only ↔ subsets) — the preset tab gates the transmitted
+  arrays. The rangesweep capture announces `:49` just before the operator's
+  sweep begins.
 
 **Important (issues #32/#35):** across the full 06-10 capture the **only**
 changing bytes in any config frame are the port/stbd string label and the
@@ -376,6 +387,27 @@ The driver's control path (from `commands.py`; envelope in §1). Builders:
 **Gap (issue #32 deliverable B):** there is **no** auto-range-disable /
 force-manual-range builder — needed only to hold a fixed swath against the
 chartplotter's auto-range.
+
+### 4.7 Chartplotter-side streams (bench inventory; not consumed by the driver)
+
+The 06-05 bucket captures show the chartplotter (`172.16.6.64`) broadcasting
+on several groups beyond `:51000`. Inventoried for completeness — none
+carries the range (checked against the operator range sweep) and the driver
+consumes none of them:
+
+| Stream | id | Len | Rate | Content |
+|---|----|----|------|---------|
+| `239.254.2.2:50050` | `8e03` | **70** | 0.2/s | chartplotter status: nine-entry `<u8 key> 00 <u16 value>` settings table (keys `1a/03/16/08/43/17/45/44/15`; static through the TVG/preset session — not TVG), the same cycling ASCII-fragment window at 17–19 as the GCV frames, device id + counter tail |
+| `239.254.2.4:8322` | — | 108 | 0.5/s | **position broadcast**: lat/lon as float64 radians at offsets 20–35 (reads 43°N, −71°W on the bench), plus undecoded floats |
+| `239.254.2.18:51400` | `050a` | 14/16 | 0.5/s | constant pair (record grammar; field values static) |
+| `239.254.2.22:51950` | `4719`/`4819` | 33/26 | 0.4/s | heartbeats — only a u16 counter changes |
+| `239.254.2.14:50615` | `fd09` | 16 | 4 every 10 s | periodic 4-frame enumeration burst, constant pattern |
+| `224.0.0.1:50030`, `233.89.188.1:10001`, SSDP `:1900` | — | — | — | discovery/beacon traffic |
+
+**Capture-topology caveat:** the 06-05 sniff port saw only switch-flooded
+traffic — these captures contain **zero unicast** between chartplotter and
+GCV, so the actual command sessions (range, settings) are invisible in them.
+A port-mirror or inline tap is required to capture those (§6, #32-B).
 
 ---
 
@@ -407,11 +439,16 @@ bottom range and v2 scaling (§4.1) and disproved the `0xe4`-as-depth reading
   TCP experiment (send a `0x0000`-high command); don't test on a live survey
   unit.
 - **The chartplotter→GCV range-command path.** Range is not re-broadcast on
-  `:51000` (auto or manual) nor `:50050`; the chartplotter presumably commands
-  over TCP `:50227`. The 06-05 `gcv20_rangesweep` / `gcv20_settings` pcaps
-  were sniffed while the operator changed range/settings — **if they captured
-  that TCP session, the auto-range-disable / force-manual frames (#32
-  deliverable B) are sitting in them.** Next RE target.
+  `:51000` (auto or manual) nor `:50050`. The 06-05 pcaps were checked for
+  the command session (2026-06-11): they contain **zero TCP and zero
+  GCV↔chartplotter unicast** — the sniff port only saw switch-flooded
+  (multicast/broadcast) traffic, so the unicast command session is invisible
+  at that capture point. **#32 deliverable B therefore needs a port-mirror /
+  inline-tap capture** of the chartplotter↔GCV link; nothing more can be
+  extracted passively from the existing captures.
+- **The 70-byte chartplotter `8e03` key-value table** (§4.7): nine keys,
+  static through the TVG/preset session — meanings unknown. A mirrored or
+  longer capture across more setting changes would map them.
 - **Gain steps at the field2 tag-length transitions** (the ex-"bracket", i.e.
   when the bottom range crosses 4.10 m / 8.19 m, and at auto-range changes) —
   a range/depth-coupled TVG/AGC applied before sending samples. Whether a

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -17,7 +17,9 @@ decodes and the structural analysis here come from the wet captures below.
 
 | Capture | Contents | Used for |
 |---|---|---|
-| GCV-10 survey pcap (Dan) | imagery, 2 channels | render-layer model, GCV-10 fixtures |
+| GCV-10 survey pcap (Dan, `dumpcap_file.pcap`) | imagery, 2 channels (1/3), 20 m commanded range | render-layer model, GCV-10 fixtures, grammar + v2=20.00 m validation |
+| `gcv10_20260605-050008.pcap` (bench) | imagery, 3 channels (0/2/5) | GCV-10 grammar validation; down-look beam byte `0x0d` confirmed on GCV-10 |
+| `gcv20_rangesweep_20260605-024550.pcap` (bucket) | all planes, **operator range sweep 3→15 m in 1 m steps + ramp to 50 m** | v2 = the commanded range (exact integers, staircase matches operator actions); config/status behavior under manual range changes |
 | 2026-06-05/09 GCV-20 bench/wet | imagery | GCV-20 echo layer, trailer fix (#26), fixtures |
 | `bag_2026-06-10T15.54.41` | all 4 streams, 20 min, **2 Cod Rock auto-range transitions**, M3 in same bag | sub-header varints (M3-validated), status/config decode, auto-range behavior |
 | `bag_2026-06-11T15.35.08` | all 4 streams, 30 min | independent re-verification sweep: envelope 100%, rates/lengths, d807 channel tag, rare status sub-types |
@@ -66,12 +68,12 @@ imagery/command, `0x08` = config; status sits on its own):
 
 All multicast streams are listen-only; the TCP command path is the only thing
 the driver sends. Lengths and rates are measured (2026-06-10 + 2026-06-11
-captures); imagery sizes and rates vary with the range bracket and ping rate.
+captures); imagery sizes and rates vary with depth/range and ping rate.
 
 | Message | id | Transport | Dir | Len (B) | Rate | Purpose | Decode |
 |---------|-----|-----------|:---:|---------|------|---------|--------|
 | Imagery data | `eb07` | `239.254.2.1:50220` UDP | in | 544–956 | ~200/s pinging | side/down scan-line sample packets | ✅ `decode.py` |
-| Channel marker | `d807` | same | in | 14–16 | 3 × ping rate | delimits one channel's packet run; carries channel tag + current bracket/bottom-range (§3.C) | ✅ |
+| Channel marker | `d807` | same | in | 14–16 | 3 × ping rate | delimits one channel's packet run; two-field record: channel tag + that run's bottom range (§3.C) | ✅ |
 | Keepalive | `d107` | same | in | 22 | 1/s | chartplotter-master keepalive that sustains pinging | ⚠️ envelope only |
 | Status | `8e03` | `239.254.2.2:50050` UDP | in | 34 | 0.2/s | tx flag / settings echo + held `0xe4` value (NOT depth) + rare one-shot sub-types | ◐ §4.4 |
 | Config heartbeat | `e708` | `239.254.2.11:51000` UDP | in | 19 | 1/s | device-id heartbeat (static) | ✅ static |
@@ -84,51 +86,76 @@ Decode legend: ✅ understood · ◐ partial · ⚠️ envelope only.
 
 ## 3. Shared patterns
 
-### A. Node descriptor: `<n> 01 03 0d <5-byte node id>`
+### A. The record grammar: tagged fields
 
-The config and keepalive payloads open with the same shape:
+Payloads are **tagged records**, one grammar across every frame type:
 
 ```
-e7 08 (heartbeat) payload:  03 01 03 0d  90 db a2 88 0b  11 01
-e5 08 (record)    payload:  05 01 03 0d  90 db a2 88 0b  1f 15 …key…
-d1 07 (keepalive) payload:  04 01 03 0d  d5 a7 f2 8b 0d  12 8a 18 19 03
-                            ▲  └ tag ┘  └─ node id ──┘
-                            leading count?
+record :=  <field count>  field*
+field  :=  <tag byte> <value>
+tag    :=  (field# << 3) | L     L = 1..6 → value is an L-byte LEB128 varint
+                                 L = 7    → next byte is an explicit length,
+                                            then that many value bytes
 ```
 
-- `01 03 0d` is a fixed descriptor tag.
-- The **5-byte node id** differs by source — `90 db a2 88 0b` on the config
-  plane vs `d5 a7 f2 8b 0d` on the keepalive — i.e. **two devices** announcing
-  on the bus (GCV vs chartplotter master). Re-verified 2026-06-11: both
-  payloads byte-identical across every frame of the capture (1788 / 1799).
+Verified with **zero exceptions on 697k+ frames across five captures and both
+generations** (every eb07 sub-header, every d807 marker, and the
+d107/e708/e508 payloads walk it exactly). Worked examples:
+
+```
+d107 keepalive:  04 | 01 03 | 0d <5-byte id> | 12 8a 18 | 19 03
+                 cnt  f0=3    f1 = node id     f2 (2 B)    f3 = 3
+e708 heartbeat:  03 | 01 03 | 0d <5-byte id> | 11 01
+                 cnt  f0=3    f1 = node id     f2 = 1
+e508 record:     05 | 01 03 | 0d <5-byte id> | 1f 15 <21-B name> | 27 74 <116-B body> | 2f 08 <8-B timestamp>
+                 cnt  f0=3    f1 = node id     f3, L=7 escape      f4, L=7 escape       f5, L=7 escape
+d807 marker:     02 | 0x10|L <v1> | 19 <channel>
+                 cnt  f2 = bottom   f3 = channel
+```
+
+Consequences worth naming:
+
+- The infamous **eb07 byte 13** — read first as a "generation tag", then as a
+  "coarse range bracket" — is **field 2's tag**: `0x11/0x12/0x13` is just the
+  v1 varint's byte length, stepping when the bottom range crosses the LEB128
+  length boundaries at **4.10 m and 8.19 m**. There is no bracket ladder.
+- The "node descriptor" opening `<n> 01 03 0d <5 bytes>` is the grammar:
+  count `n`, field0 = 3 (a protocol version?), field1 = the sender's **5-byte
+  node id** (`0x0d` = field1, length 5). Two ids on the bus — `90 db a2 88 0b`
+  (GCV, config plane) vs `d5 a7 f2 8b 0d` (chartplotter, keepalive) —
+  byte-identical across every frame of the 2026-06-11 capture (1788 / 1799).
+- Field numbers are scoped **per message type** (field2 is v1 in imagery
+  frames, a 2-byte unknown in the keepalive).
 
 ### B. LEB128 varints, 0.5 mm range unit
 
 Unsigned base-128 varints are the protocol's number format: the TCP range
-command value, the imagery sub-header's three range fields (§4.1), and the
+command value, the imagery sub-header's range fields (§4.1), and the
 `e508` record timestamps all use them. Range-like values are in **0.5 mm
 units** (the TCP range command's unit).
 
 ### C. The `d807` marker: channel tag + that run's range fields
 
-The common marker payload (14–15 B total frame) is:
+The common marker payload (14–15 B total frame) is a two-field record:
 
 ```
-02  <bracket>  <v1 varint>  19  <channel>
+02  |  0x10|L <v1 varint>  |  19 <channel>
+cnt    field2 = bottom range   field3 = channel
 ```
 
 Markers **bracket** channel runs — they appear in close/open pairs at run
 boundaries (visible in the GCV-20 fixture: `…19 02`, `…19 01` between a ch2
-and a ch1 run). Each marker **tags an adjacent run's channel** (the trailing
-byte after the `0x19` tag, cycling `00`/`01`/`02` in exactly equal thirds —
-20,330/20,329/20,331 in the 2026-06-11 capture) and carries **that run's**
-byte-13 bracket + bottom-range varint (§4.1). Verified per-marker against
-both neighbours on the full 2026-06-11 capture: **94 %** match the preceding
-(79 %, close) or following (15 %, open) run's channel *and* v1 exactly; the
-residual is packet loss plus the sub-form below parsed as if common-form.
+and a ch1 run). Each marker **tags an adjacent run's channel** (field3,
+cycling `00`/`01`/`02` in exactly equal thirds — 20,330/20,329/20,331 in the
+2026-06-11 capture) and carries **that run's** v1 bottom range (§4.1).
+Verified per-marker against both neighbours on the full 2026-06-11 capture:
+**94 %** match the preceding (79 %, close) or following (15 %, open) run's
+channel *and* v1 exactly; the residual is packet loss plus the sub-form below
+parsed as if common-form.
 
-- A 16-byte sub-form (`02 0c … 41 19 <channel>`, 780 frames ≈ 1.2 %) carries
-  a different inner layout — **undecoded** (§6).
+- A 16-byte sub-form (`02 0c <4-byte field1 value> 19 <channel>`, 780 frames
+  ≈ 1.2 %, in channel triplets ~every 1.4 s) carries **field1 with a 4-byte
+  value instead of field2** — the value's meaning is open (§6).
 
 The assembler treats any `d807` as "flush the current channel's
 accumulation"; the channel tag and range fields are not needed for assembly
@@ -150,53 +177,51 @@ after the 8-byte envelope):
 
 | offset | meaning |
 |-------:|---------|
-| 8 | render-layer / beam-type byte: `0x0d` down-look (water column), `0x0e`/`0x0f` side-scan |
-| 12 | channel number (GCV-20 map: 0 = port, 1 = stbd, 2 = down) |
-| 13 | **range/scale index** — the coarse display bracket; steps with range (`0x11`/`0x12`/`0x13` seen), shared by all channels. NOT a generation tag (see below). |
-| 14… | three LEB128 varints with fixed markers — see below |
+| 8 | render-layer / beam-type byte: `0x0d` down-look (water column) on **both generations** (GCV-20 wet + GCV-10 bench verified), `0x0e` (GCV-20) / `0x0f` (GCV-10) side-scan |
+| 9–10 | `01 03` — field0 = 3 (grammar §3.A) |
+| 11–12 | `09 <channel>` — field1 = channel number (maps vary by unit/config: GCV-20 0/1/2; GCV-10 survey 1/3; GCV-10 bench 0/2/5) |
+| 13… | fields 2–6 of the record grammar — see below |
 
 Frequency and a per-ping timestamp are **not** carried; the driver takes
 frequency from a parameter and stamps scan lines with receive time.
 
-#### The sub-header varints: v1 bottom range, v2 display range, v3
+#### The sub-header fields: v1 bottom range, v2 display range, v3
 
-The full sub-header is three LEB128 varints (all in **0.5 mm** units)
-bracketed by fixed markers. Structure verified byte-for-byte on **29,267
-packets, 0 mismatches** (`parse_subheader`); the same layout is present on
-every channel:
+The sub-header continues the record grammar (§3.A); range values are LEB128
+varints in **0.5 mm** units. `parse_subheader` walks it field-by-field —
+verified with zero exceptions on every eb07 frame of five captures (697k+):
 
 ```
-08: 0d 01 03 09   beam (0d=down) + const
-12: <channel>
-13: <bracket>     coarse range index (byte 13, above)
-14: v1  ───────── BOTTOM RANGE   (depth; 7.1–19.9 m; corr 1.00 / ratio 1.013 vs M3)
-    19 00 23      marker
-    v2  ───────── DISPLAY RANGE  (scan extent; tracks hardware auto-range)
-    2a            marker
-    v3  ───────── ~88–99 mm      (near-field / start range?; corr 0.94; meaning TBD)
-    31 02 3f      const
-    da 04 d8 04   FH header → samples begin
+field2  (tag 0x10|L):  v1  BOTTOM RANGE   (M3: corr 1.00 / ratio 1.013; bucket: 0.38 m)
+field3  (tag 0x19):    value 0 in imagery frames (the channel in d807 markers)
+field4  (tag 0x20|L):  v2  DISPLAY RANGE  (this channel's scan extent)
+field5  (tag 0x28|L):  v3  ~64–100 mm     (near-field / start range?; corr 0.94; meaning TBD)
+field6  (tag 0x31):    value 2
+3f  da 04 d8 04        FH header → samples begin
 ```
 
 - **v1 = measured bottom range**, per ping, **shared across all channels**
-  (the boat's depth; near-exact vs M3). The driver publishes it as
-  `~/nadir_depth` (issues #16/#35).
-- **v2 = this channel's own display range** — the auto-ranged scan extent,
-  **per channel**: on the down-look it is the water-column depth range; on the
-  side-scan it is the across-track slant range (~2×). So
-  **`bin_size = v2 / n_bins`** must use the matching channel's v2 — no bottom
-  detection, no calibration ladder, no M3. Verified to track **both** Cod Rock
-  auto-range transitions (side-scan 47.8 → 30.4 → 50.4 → 29.8 → 48.9 m at
-  t≈153/202/561/592 s, 2026-06-10) in lockstep with the byte-13 bracket while
-  the driver's commanded mirror held `60.0`. The driver derives the published
+  (the boat's depth; near-exact vs M3 at 7–20 m, and 0.38 m in the bucket
+  test). The driver publishes it as `~/nadir_depth` (issues #16/#35).
+- **v2 = this channel's own display range**, and it is **the real range under
+  every control regime**, verified three ways: it tracks both Cod Rock
+  **auto-range** transitions (side-scan 47.8 → 30.4 → 50.4 → 29.8 → 48.9 m,
+  2026-06-10) while the driver's commanded mirror held `60.0`; it reads the
+  **operator's chartplotter range steps as exact integers** (5→4→3,
+  4,5,…,15 m staircase then the ramp to 50 m — the 06-05 bucket sweep); and
+  Dan's survey reads a flat **20.00 m**. Per channel: side-scan = the
+  across-track slant range (= commanded range when one is set); **down-look =
+  the water-column depth range, always auto** (it ignored the bucket sweep,
+  holding its own 1.84 m). So **`bin_size = v2 / n_bins`** must use the
+  matching channel's v2. The driver derives the published
   `RawSonarImage.sample_rate` from it (#35).
-- **v3 ≈ 96 mm**, weakly depth-correlated — a candidate near-field/blanking or
-  start-range term (§6).
+- **v3** small (~64–100 mm), weakly depth-correlated — a candidate
+  near-field/blanking or start-range term (§6). GCV-10 encodes it as a 1-byte
+  varint (tag `0x29`), GCV-20 typically 2-byte (`0x2a`) — same field, just the
+  length bits.
 
-byte 13 is the coarse bracket that gates which range band v2 lives in; v2 is
-the actual per-ping range. `n_bins` (~2034) is **not** a range control — its
-short values (848/1148/1500/1748 ≈ 2034 − N×309) are dropped-packet assembly
-artifacts.
+`n_bins` (~2034) is **not** a range control — its short values
+(848/1148/1500/1748 ≈ 2034 − N×309) are dropped-packet assembly artifacts.
 
 #### Distinguishing the beams (down / port / starboard)
 
@@ -206,9 +231,9 @@ Diffing the three channels' sub-headers within one range/time window
 | offset | port (ch0) | stbd (ch1) | down (ch2) | note |
 |-------:|:----------:|:----------:|:----------:|------|
 | 8 | `0e` | `0e` | **`0d`** | beam type — separates **down vs side-scan** only |
-| 9–11 | `01 03 09` | `01 03 09` | `01 03 09` | constant |
-| **12** | **`00`** | **`01`** | **`02`** | **channel number** |
-| 13 | `13` | `13` | `13` | range index (same on all channels) |
+| 9–11 | `01 03 09` | `01 03 09` | `01 03 09` | field0 = 3, field1 tag |
+| **12** | **`00`** | **`01`** | **`02`** | **channel number** (field1 value) |
+| 13 | `13` | `13` | `13` | field2 tag — same on all channels because v1 is shared |
 
 - **Down vs side-scan** is intrinsic at **offset 8** (`0x0d` down vs
   `0x0e`/`0x0f` side; the `0x0e`/`0x0f` split is generation, not side).
@@ -216,19 +241,20 @@ Diffing the three channels' sub-headers within one range/time window
   identical in the sub-header **except the channel number at offset 12**, so
   the driver maps side from the channel number via the `port_channels` /
   `stbd_channels` params. Whether an intrinsic side marker exists elsewhere is
-  **not established**; the channel→side mapping differs by generation (GCV-20
-  `0/1/2` vs the GCV-10 survey `3/1`).
+  **not established**; the channel→side mapping varies by unit/config (GCV-20
+  `0/1/2`; GCV-10 survey `3/1`; GCV-10 bench `0/2/5`).
 
-#### Byte 13 is a range/scale index, not a generation tag
+#### Byte 13: a generation tag that wasn't, then a range bracket that wasn't
 
 `decode.py` historically read offset 13 as a GCV-10-vs-GCV-20 "generation
-tag". The 2026-06-10 data disproves this: on a single GCV-20, byte 13 takes
-`0x11`/`0x12`/`0x13` purely as a function of range — identical on all three
-channels, stepping at the auto-range transitions — and the GCV-10 survey
-fixture reads `0x13`, the same value a GCV-20 produces in deep water. A value
-shared across generations cannot be a generation tag. It is the **coarse range
-bracket** (higher = longer range); converting it to metres would need a
-calibrated ladder (only `0x11`–`0x13` seen; §6).
+tag"; the 2026-06-10 capture disproved that and recast it as a "coarse range
+bracket" (`0x11`–`0x13`, stepping with range). The record grammar (§3.A)
+dissolves the bracket too: byte 13 is **field2's tag**, and its low bits are
+the **v1 varint's byte length** — it "steps with range" only because the
+bottom range crosses the LEB128 length boundaries at **4.10 m / 8.19 m**
+(1→2→3 bytes). Both prior readings were correlates of depth. Note device
+**gain steps at these same transitions** (§6) — the only observable that
+still keys on this byte.
 
 #### Generation is recoverable from packet structure (range-independent)
 
@@ -241,7 +267,7 @@ independent of range:
 | **GCV-20** | ≤2 | **0 or 1** | first (`FH`) layer | 16-bit LE (`UINT16`) |
 
 Verified: every GCV-10 fixture packet has two later-layer headers; every
-GCV-20 packet (fixtures *and* the 06-10 bag, at both byte-13 ranges) has at
+GCV-20 packet (fixtures *and* the 06-10 bag, across depth/range changes) has at
 most one. So a packet is classified **per-packet by counting its `SH`/`SHS`
 headers (≥2 → GCV-10, ≤1 → GCV-20)** — implemented as
 `decode.generation_from_layers()`, voted over a few packets by the node's
@@ -251,7 +277,7 @@ relying on it.)
 ### 4.2 Channel marker — `d807`
 
 14–16 byte delimiter emitted between channel runs; payload decoded in
-[§3.C](#c-the-d807-marker-channel-tag--current-range-measurement). The
+[§3.C](#c-the-d807-marker-channel-tag--that-runs-range-fields). The
 assembler treats it as "flush the current channel's accumulation."
 
 ### 4.3 Keepalive — `d107`
@@ -286,9 +312,13 @@ captures (215 + 359 frames).
 **Sub-type `0x00` / `0x01` — settings echo and transmit flag.** `0x00` =
 transmitting, `0x01` = off (the only sub-types the driver reads —
 `decode.status_transmitting`; all others return "unknown" so they cannot flap
-the flag). Offsets 17–23 = `ae 05 c0 75 ae 05 c0`, **constant** through both
-captures including the auto-range transitions — a stale commanded/configured
-echo, NOT the active range. Field decode unconfirmed and not needed.
+the flag). Offsets 17–23: `ae 05 c0 75 ae 05 c0`, **constant** through both
+wet captures including the auto-range transitions — a stale
+commanded/configured echo, NOT the active range. On the 06-05 **bench**
+captures, though, this region cycles through many values including
+ASCII-looking fragments (`",13"`, `"nit"`, `"7,R"`, zeros…) — possibly a
+windowed text/diagnostic stream. Field decode open (§6) and not needed by the
+driver.
 
 **Sub-type `0xe4` — a held value of unconfirmed meaning (NOT depth).** A u16
 LE at offset 20 (offsets 17–19/22–23 zero). Cross-checked against the M3: it
@@ -322,7 +352,10 @@ bus):
 **Important (issues #32/#35):** across the full 06-10 capture the **only**
 changing bytes in any config frame are the port/stbd string label and the
 per-frame timestamp tail. **No range field, nothing steps at the Cod Rock
-auto-range transitions.** The active range is *not* on this stream — but it
+auto-range transitions — and the record bodies stayed byte-identical through
+the entire 06-05 operator range sweep too**, so range is not on this stream
+under auto OR manual control (the chartplotter must command the GCV by
+another path, presumably its own TCP `:50227` session). The active range
 **is** passively available: each channel's per-ping sub-header **v2** (§4.1)
 is that channel's true active display range. The driver derives the published
 `RawSonarImage.sample_rate` from it (#35). Pinning/disabling auto-range over
@@ -360,23 +393,31 @@ bottom range and v2 scaling (§4.1) and disproved the `0xe4`-as-depth reading
 
 ## 6. Open questions
 
-- **v3** (~0.1 m, weakly depth-coupled) — near-field/blanking/start-range?
-- **Byte 13 → metres.** Only `0x11`–`0x13` seen; a TCP range-sweep would map
-  the full bracket ladder.
+- **v3** (~0.06–0.1 m, weakly depth-coupled) — near-field/blanking/start-range?
 - **`0xe4` value** — held, not depth; meaning open. **New 2026-06-11:**
   one-shot sub-types `0x09`/`0x1f` (float-pair-like) and `0xed` (same shape as
   `0xe4`) — a `:50050` capture across known device state changes (transmit
   on/off, range commands, frequency switch) would decipher the family.
-- **`d807` 16-byte sub-form** (`02 0c … 41 19 <ch>`, ~1.2 % of markers) —
-  inner layout unknown.
+- **`0x00`-status offsets 17–23**: constant `ae 05 c0 75 ae 05 c0` on the
+  boat, but cycling values with ASCII fragments on the bench — windowed
+  text/diagnostic stream? Sequence-reassemble the 06-05 bench frames.
+- **`d807` field1 sub-form** (`02 0c <4 raw bytes> 19 <ch>`, ~1.2 % of
+  markers, periodic ~0.7 Hz per channel) — the 4-byte value's meaning.
 - **`0xBEEF` command high half** — required by the device, or cosmetic? One
   TCP experiment (send a `0x0000`-high command); don't test on a live survey
   unit.
-- **Gain coupled to the range bracket.** Raw sample brightness *steps* at each
-  byte-13 transition (higher gain at short range) — a range-coupled TVG/AGC
-  applied before sending samples. Whether a separate gain field exists is
-  open. The driver publishes samples as-is; gain normalization is a
-  downstream concern.
-- **Node id bodies** (`90 db a2 88 0b`, `d5 a7 f2 8b 0d`), **`e508` value
-  records**, and the **`0x00`-status settings block** (`ae 05 c0 …`) — field
-  decodes unknown; not yet needed.
+- **The chartplotter→GCV range-command path.** Range is not re-broadcast on
+  `:51000` (auto or manual) nor `:50050`; the chartplotter presumably commands
+  over TCP `:50227`. The 06-05 `gcv20_rangesweep` / `gcv20_settings` pcaps
+  were sniffed while the operator changed range/settings — **if they captured
+  that TCP session, the auto-range-disable / force-manual frames (#32
+  deliverable B) are sitting in them.** Next RE target.
+- **Gain steps at the field2 tag-length transitions** (the ex-"bracket", i.e.
+  when the bottom range crosses 4.10 m / 8.19 m, and at auto-range changes) —
+  a range/depth-coupled TVG/AGC applied before sending samples. Whether a
+  separate gain field exists is open. The driver publishes samples as-is;
+  gain normalization is a downstream concern.
+- **Field semantics not yet needed**: keepalive field2 (`8a 18`) and
+  field3 = 3; e708 field2 = 1; field0 = 3 everywhere (version?); node-id
+  bodies (`90 db a2 88 0b`, `d5 a7 f2 8b 0d`); the `e508` nested body values
+  (mechanically walkable now via the §3.A grammar).

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -333,9 +333,10 @@ The offset-20 `u16` is **not a depth**: it is **held** (one value for tens of
 seconds), lags the M3 nadir by 2–7 m, and does not track the bottom (it only
 *looked* depth-like because its mean and Cod-Rock dips happened to align). Its
 meaning is unconfirmed — likely a mode/status field. The driver does **not**
-decode or publish it. A real per-ping bottom range is instead in the **down-look
-imagery sub-header** (§3.1, offset-14 varint); for a nadir *depth*, bottom-track
-the down-look in a downstream node (issue #16).
+decode or publish it. The real per-ping bottom range is instead the **down-look
+imagery sub-header v1** (§3.1, offset-14 varint, M3-validated), which the
+driver publishes as `~/nadir_depth` (issues #16/#35); draft/tide/offset
+correction is a downstream concern.
 
 **Sub-type `0x00` — settings echo (NOT the active range):**
 
@@ -358,13 +359,19 @@ bus). Two frames:
   `yutl-engn-sched-type`, `stnd-sched`, `opt-sched-1/2/3` and a trailing
   `2f 08 <LEB128 timestamp>`.
 
-**Important (issue #32):** across the full capture the **only** changing bytes
-in any config frame are the port/stbd string label and the per-frame timestamp
-tail. **No range field, nothing steps at the Cod Rock auto-range transitions.**
-The active range is *not* on this stream — the GCV auto-range derives the swath
-from depth and never re-broadcasts the resulting range as a value. Reporting a
-true active range therefore needs auto-range pinned/disabled over the command
-port (#32 deliverable B), not a passive decode.
+**Important (issues #32/#35):** across the full capture the **only** changing
+bytes in any config frame are the port/stbd string label and the per-frame
+timestamp tail. **No range field, nothing steps at the Cod Rock auto-range
+transitions.** The active range is *not* on this stream — but it **is**
+passively available after all: each channel's per-ping sub-header **v2**
+(§3.1) is that channel's true active display range, verified to track both
+Cod Rock auto-range transitions in lockstep with the byte-13 bracket
+(side-scan 47.8 → 30.4 → 50.4 → 29.8 → 48.9 m at t≈153/202/561/592 s) while
+the driver's commanded mirror held `60.0`. The driver derives the published
+``RawSonarImage.sample_rate`` from it (#35), so consumers recover the true
+per-ping range. Pinning/disabling auto-range over the command port (#32
+deliverable B) remains open as an optional survey-ops capability — for
+*holding* a fixed swath, no longer for *knowing* it.
 
 ### 3.6 Command — `d2 07 ef be` (TCP `172.16.3.0:50227`, outbound)
 
@@ -418,6 +425,9 @@ disproved the `0xe4`-as-depth reading (§3.4).
 - **Node id bodies** (`90 db a2 88 0b`, `d5 a7 f2 8b 0d`), **`e508` value
   records**, and the **`0x00`-status settings block** (`ae 05 c0 …`) — field
   decodes unknown; not yet needed.
-- **Nadir depth** — not reported usably by the device. If wanted, a downstream
-  node bottom-tracks `sonar_image_down`; draft/tide/transducer-offset correction
-  is that node's concern, not the driver's.
+- ~~**Nadir depth**~~ — **resolved (#16/#35)**: the device *does* report a real
+  per-ping bottom range — the sub-header **v1** varint (§3.1, M3-validated to
+  ~1%) — and the driver publishes it as a downward `sensor_msgs/Range` on
+  `~/nadir_depth`. (The earlier `0xe4`-status reading remains disproven, §3.4.)
+  Draft/tide/transducer-offset correction is a downstream concern, not the
+  driver's.

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -1,109 +1,90 @@
 # Garmin GCV Marine-Network protocol reference
 
 Every message the `garmin_sidescan` driver sees or sends on the Garmin Marine
-Network (GCV-10 / GCV-20), in one place. The [summary](#1-summary) is the
-at-a-glance map; [patterns](#2-cross-message-patterns) calls out the structure
-shared across messages; the [per-message detail](#3-per-message-detail) sections
-give byte layouts.
+Network (GCV-10 / GCV-20), in one place. Every claim is grounded in a capture
+or in the driver source; provenance and anything unverified are called out
+explicitly.
 
-The foundational reverse engineering of the GCV Marine-Network protocol — the
-imagery stream (`eb07`/`d807` render-layer model) and the TCP command frames
-(`d207efbe`: transmit/range/TVG/interference) — is the work of **Dan
-Tauriello**, validated live on both the GCV-10 and GCV-20. The driver's
-`decode.py` and `commands.py` implement his findings. The status (`8e03`) and
-config (`e508`/`e708`) decodes and the cross-message structural analysis in this
-document build on that base, from the 2026-06-10 capture.
+The foundational reverse engineering — the imagery stream (`eb07`/`d807`
+render-layer model) and the TCP command frames (transmit/range/TVG/
+interference) — is the work of **Dan Tauriello**, validated live on both the
+GCV-10 and GCV-20; the driver's `decode.py` and `commands.py` implement his
+findings and unit-test them, so this document summarizes and cross-links them
+rather than restating byte layouts that live in code. The status/config
+decodes and the structural analysis here come from the wet captures below.
 
-Every claim is grounded in a capture or in the driver source, not assumption.
-Provenance and anything still unverified are called out explicitly.
+**Captures** (gabby, `debug_raw:=true` bags unless noted):
 
-- **Imagery + command frames** — reverse-engineered by **Dan Tauriello**;
-  authoritatively implemented and unit-tested in `garmin_sidescan/decode.py`
-  (imagery) and `garmin_sidescan/commands.py` (TCP control, verified live on
-  both generations 2026-06-05). This reference summarizes and cross-links them
-  rather than restating them. Command frames are transmitted, not captured.
-- **Status + config decode (this document)** — from the wet capture below.
-- **Wet capture:** `bag_2026-06-10T15.54.41_sidescan_raw` (gabby), 2026-06-10
-  Piscataqua River deployment (rolker/unh_echoboats_project11#250):
-  `debug/raw` (227,777 imagery datagrams), `debug/raw_status` (215),
-  `debug/raw_config` (1,497), spanning two Cod Rock shoal passes.
-- **Ground truth (depth/bathymetry):** the M3 multibeam in the same sonar bag
-  (same clock) — used to test the `0xe4` value (§4) and the bin-size ladder.
+| Capture | Contents | Used for |
+|---|---|---|
+| GCV-10 survey pcap (Dan) | imagery, 2 channels | render-layer model, GCV-10 fixtures |
+| 2026-06-05/09 GCV-20 bench/wet | imagery | GCV-20 echo layer, trailer fix (#26), fixtures |
+| `bag_2026-06-10T15.54.41` | all 4 streams, 20 min, **2 Cod Rock auto-range transitions**, M3 in same bag | sub-header varints (M3-validated), status/config decode, auto-range behavior |
+| `bag_2026-06-11T15.35.08` | all 4 streams, 30 min | independent re-verification sweep: envelope 100%, rates/lengths, d807 channel tag, rare status sub-types |
 
 ---
 
-## 1. Summary
+## 1. The envelope
+
+Every frame, **both directions**, is one 8-byte TLV header plus payload:
+
+```
+<u32-LE message id>  <u32-LE payload length>  <payload>
+└──── offset 0-3 ───┘└────── offset 4-7 ─────┘└─ 8.. ──┘
+```
+
+- **Length** is always `total_length − 8`. Verified on **100 %** of frames:
+  427,767/427,767 across all six inbound types in the 2026-06-11 bag, and the
+  full 2026-06-10 capture. `commands.py` constructs outbound frames with the
+  same rule.
+- **Inbound ids** have a zero high half, so on the wire they read as a 2-byte
+  magic followed by `00 00` (e.g. imagery data `eb 07 00 00` = id `0x000007EB`).
+- **The outbound command id** is `d2 07 ef be` — as a u32-LE, **`0xBEEF07D2`**:
+  the same envelope with the high half set to a `0xBEEF` cookie instead of
+  zero. This is why the command frame previously looked like a "4-byte magic
+  with no pad": there is no pad anywhere, just a 32-bit id whose high half is
+  `0x0000` on the bus and `0xBEEF` from a commanding host.
+  *Caveat*: whether the device requires `0xBEEF` (vs. accepting a zero high
+  half) is untested — treat it as required.
+
+The low half groups messages into planes (high byte `0x07` =
+imagery/command, `0x08` = config; status sits on its own):
+
+| id (LE) | hex | bytes on wire | message | plane |
+|---:|-----|---------------|---------|-------|
+| 2001 | `0x07d1` | `d1 07 00 00` | keepalive | imagery |
+| 2002 | `0x07d2` | `d2 07 ef be` | command (outbound, `0xBEEF` high half) | command |
+| 2008 | `0x07d8` | `d8 07 00 00` | channel marker | imagery |
+| 2027 | `0x07eb` | `eb 07 00 00` | imagery data | imagery |
+| 2277 | `0x08e5` | `e5 08 00 00` | config record | config |
+| 2279 | `0x08e7` | `e7 08 00 00` | config heartbeat | config |
+| 910 | `0x038e` | `8e 03 00 00` | status | status |
+
+---
+
+## 2. Message summary
 
 All multicast streams are listen-only; the TCP command path is the only thing
-the driver sends. "LE id" is the 2-byte magic read as a little-endian `uint16`
-(see [pattern B](#b-the-magic-is-a-little-endian-message-type-id)).
+the driver sends. Lengths and rates are measured (2026-06-10 + 2026-06-11
+captures); imagery sizes and rates vary with the range bracket and ping rate.
 
-| Message | Magic | LE id | Transport | Dir | Len | ~Rate | Purpose | Decode |
-|---------|-------|------:|-----------|:---:|-----|------:|---------|--------|
-| Imagery data | `eb 07` | 2027 | `239.254.2.1:50220` UDP | in | 650–956 B | ~190/s | side/down scan-line sample packets | ✅ `decode.py` |
-| Channel marker | `d8 07` | 2008 | `239.254.2.1:50220` UDP | in | 15–16 B | per run | delimits one channel's packet run within a ping | ✅ |
-| Keepalive | `d1 07` | 2001 | `239.254.2.1:50220` UDP | in | 22 B | ~1 Hz | chartplotter-master keepalive that sustains pinging | ⚠️ partial |
-| Status | `8e 03` | 910 | `239.254.2.2:50050` UDP | in | 34 B | ~0.2/s | tx flag + a held `0xe4` sub-type value (NOT depth — §3.4) / settings echo | ◐ this doc |
-| Config heartbeat | `e7 08` | 2279 | `239.254.2.11:51000` UDP | in | 19 B | ~1/s | device-id heartbeat | ⚠️ partial |
-| Config record | `e5 08` | 2277 | `239.254.2.11:51000` UDP | in | 168 / 173 B | bursts | named CDP ping-schedule key/values | ◐ structure ✅, values partial |
-| Command | `d2 07 ef be` | 2002 | `172.16.3.0:50227` TCP | **out** | varies | on demand | transmit / range / TVG / interference | ✅ `commands.py` |
+| Message | id | Transport | Dir | Len (B) | Rate | Purpose | Decode |
+|---------|-----|-----------|:---:|---------|------|---------|--------|
+| Imagery data | `eb07` | `239.254.2.1:50220` UDP | in | 544–956 | ~200/s pinging | side/down scan-line sample packets | ✅ `decode.py` |
+| Channel marker | `d807` | same | in | 14–16 | 3 × ping rate | delimits one channel's packet run; carries channel tag + current bracket/bottom-range (§3.C) | ✅ |
+| Keepalive | `d107` | same | in | 22 | 1/s | chartplotter-master keepalive that sustains pinging | ⚠️ envelope only |
+| Status | `8e03` | `239.254.2.2:50050` UDP | in | 34 | 0.2/s | tx flag / settings echo + held `0xe4` value (NOT depth) + rare one-shot sub-types | ◐ §4.4 |
+| Config heartbeat | `e708` | `239.254.2.11:51000` UDP | in | 19 | 1/s | device-id heartbeat (static) | ✅ static |
+| Config record | `e508` | same | in | 168/173 | bursts (~0.4/s avg) | named CDP ping-schedule key/values | ◐ structure ✅, values partial |
+| Command | `d207` (`0xBEEF` high) | `172.16.3.0:50227` TCP | **out** | varies | on demand | transmit / range / TVG / interference | ✅ `commands.py` |
 
 Decode legend: ✅ understood · ◐ partial · ⚠️ envelope only.
 
-**Three logical planes:**
-
-- **Imagery plane** — `239.254.2.1:50220`: `eb07` data, `d807` markers, `d107`
-  keepalive. The data/control plane (`0x07xx` ids).
-- **Status plane** — `239.254.2.2:50050`: `8e03` only.
-- **Config plane** — `239.254.2.11:51000`: `e708` heartbeat + `e508` records
-  (`0x08xx` ids).
-- **Command plane (outbound)** — TCP `:50227`: `d2 07 ef be` frames. The driver
-  uses this to control the sonar directly, sidestepping the chartplotter's CDP.
-
 ---
 
-## 2. Cross-message patterns
+## 3. Shared patterns
 
-The whole protocol is built from a few repeated shapes — this is the part worth
-scanning for structure.
-
-### A. One universal envelope
-
-Every **inbound** frame is:
-
-```
-<2-byte magic>  00 00  <uint32 LE payload-length>  <payload>
-└── offset 0 ──┘└ 2-3 ┘└──── offset 4..7 ───────┘ └ 8.. ┘
-```
-
-Verified to hold on **100 %** of captured frames of every type
-(`payload-length == total_len − 8` for all eb07/d807/d107/8e03/e708/e508). The
-`00 00` after the magic is always zero — likely a 16-bit high half of a 32-bit
-message id, or a reserved field.
-
-The **outbound TCP command** is the one variant: a **4-byte** magic
-`d2 07 ef be` + `uint32 LE length` + payload, with no `00 00` pad. Note it still
-opens `d2 07` — the same `0x07xx` family as the imagery plane.
-
-### B. The magic is a little-endian message-type id
-
-Read each magic as LE `uint16` and a numbering appears:
-
-| id | hex | message | plane |
-|---:|-----|---------|-------|
-| 2001 | `0x07d1` | keepalive | imagery |
-| 2002 | `0x07d2` | command (`d207…`) | command |
-| 2008 | `0x07d8` | channel marker | imagery |
-| 2027 | `0x07eb` | imagery data | imagery |
-| 2277 | `0x08e5` | config record | config |
-| 2279 | `0x08e7` | config heartbeat | config |
-| 910 | `0x038e` | status | status |
-
-The high byte groups the plane: `0x07xx` = imagery/command, `0x08xx` = config.
-Status (`0x038e`) sits on its own. Useful as a sanity filter when sniffing raw
-traffic: anything `?? 07` / `?? 08` / `8e 03` is GCV.
-
-### C. A recurring node descriptor: `<n> 01 03 0d <5-byte node id>`
+### A. Node descriptor: `<n> 01 03 0d <5-byte node id>`
 
 The config and keepalive payloads open with the same shape:
 
@@ -118,141 +99,71 @@ d1 07 (keepalive) payload:  04 01 03 0d  d5 a7 f2 8b 0d  12 8a 18 19 03
 - `01 03 0d` is a fixed descriptor tag.
 - The **5-byte node id** differs by source — `90 db a2 88 0b` on the config
   plane vs `d5 a7 f2 8b 0d` on the keepalive — i.e. **two devices** announcing
-  on the bus (GCV vs chartplotter master). The trailing `0b` / `0d` and the
-  4-byte body look MAC/serial-derived.
-- The leading byte (`03` / `04` / `05`) looks like a field/record count.
+  on the bus (GCV vs chartplotter master). Re-verified 2026-06-11: both
+  payloads byte-identical across every frame of the capture (1788 / 1799).
 
-### D. The `d807` marker echoes the ping's range fields
+### B. LEB128 varints, 0.5 mm range unit
 
-The `d807` channel marker embeds the same bytes that open the `eb07` sub-header
-of the run it delimits — the **range bracket + bottom-range varint** (§3.1), not
-a sequence id:
+Unsigned base-128 varints are the protocol's number format: the TCP range
+command value, the imagery sub-header's three range fields (§4.1), and the
+`e508` record timestamps all use them. Range-like values are in **0.5 mm
+units** (the TCP range command's unit).
 
-```
-eb 07 …envelope… 0e 01 03 09 00 | 13 | ea ef 01 | 19 00 23 …samples…
-d8 07 …envelope…             02 | 13 | ea ef 01 | 19 00
-                                  └bracket┘└─ v1 ─┘└marker
-```
+### C. The `d807` marker: channel tag + that run's range fields
 
-So a marker is not a bare delimiter — it carries that run's range bracket and
-measured bottom range, which is why the shared bytes change every ping (they
-track depth, not a counter).
-
-### E. CDP named TLV + LEB128 values
-
-Config records (`e508`) are ASCII-keyed type-length-value:
+The common marker payload (14–15 B total frame) is:
 
 ```
-<tag> <len> <key-ascii> 00 <value-record> …   (repeated)   2f 08 <LEB128 timestamp>
+02  <bracket>  <v1 varint>  19  <channel>
 ```
 
-Keys seen: `yutl-port/stbd/cntr-engn-sched`, `yutl-engn-sched-type`,
-`stnd-sched`, `opt-sched-1/2/3`. Records close with a `2f 08`-tagged **LEB128
-varint timestamp**. The same unsigned base-128 varint encodes the **range value
-(0.5 mm units)** in the TCP command — so LEB128 is the protocol's number format.
+Markers **bracket** channel runs — they appear in close/open pairs at run
+boundaries (visible in the GCV-20 fixture: `…19 02`, `…19 01` between a ch2
+and a ch1 run). Each marker **tags an adjacent run's channel** (the trailing
+byte after the `0x19` tag, cycling `00`/`01`/`02` in exactly equal thirds —
+20,330/20,329/20,331 in the 2026-06-11 capture) and carries **that run's**
+byte-13 bracket + bottom-range varint (§4.1). Verified per-marker against
+both neighbours on the full 2026-06-11 capture: **94 %** match the preceding
+(79 %, close) or following (15 %, open) run's channel *and* v1 exactly; the
+residual is packet loss plus the sub-form below parsed as if common-form.
+
+- A 16-byte sub-form (`02 0c … 41 19 <channel>`, 780 frames ≈ 1.2 %) carries
+  a different inner layout — **undecoded** (§6).
+
+The assembler treats any `d807` as "flush the current channel's
+accumulation"; the channel tag and range fields are not needed for assembly
+(the run's own `eb07` sub-headers carry the same fields authoritatively).
 
 ---
 
-## 3. Per-message detail
+## 4. Per-message detail
 
-### 3.1 Imagery data — `eb07` (`239.254.2.1:50220`)
+### 4.1 Imagery data — `eb07` (`239.254.2.1:50220`)
 
-Side-scan and down-look sample packets; a scan line is reassembled from a run of
-same-channel packets bracketed by `d807` markers. The render-layer model
+Side-scan and down-look sample packets; a scan line is reassembled from a run
+of same-channel packets bracketed by `d807` markers. The render-layer model
 (per-generation echo extraction, GCV-10 "dark layer" vs GCV-20 16-bit first
-layer, trailer/leading-header stripping) was reverse-engineered by **Dan Tauriello**
-and is fully documented and unit-tested in **`decode.py`** — refer there for the
-authoritative layout. Key sub-header bytes
-(full-frame offsets, after the 8-byte envelope):
+layer, trailer/leading-header stripping) was reverse-engineered by **Dan
+Tauriello** and is fully documented and unit-tested in **`decode.py`** — refer
+there for the authoritative layout. Key sub-header bytes (full-frame offsets,
+after the 8-byte envelope):
 
 | offset | meaning |
 |-------:|---------|
 | 8 | render-layer / beam-type byte: `0x0d` down-look (water column), `0x0e`/`0x0f` side-scan |
 | 12 | channel number (GCV-20 map: 0 = port, 1 = stbd, 2 = down) |
 | 13 | **range/scale index** — the coarse display bracket; steps with range (`0x11`/`0x12`/`0x13` seen), shared by all channels. NOT a generation tag (see below). |
-| 14… | **LEB128 varint** — on the down-look, the per-ping **measured bottom range** (~0.5 mm units, see below). Variable length (2–3 B), then a `19 00 23` marker. (The `d807` marker echoes this bracket + varint — [pattern D](#d-the-d807-marker-echoes-the-pings-range-fields) — not a sequence counter.) |
+| 14… | three LEB128 varints with fixed markers — see below |
 
 Frequency and a per-ping timestamp are **not** carried; the driver takes
-frequency from a parameter and stamps scan lines with receive time (see
-`decode.py` / README).
+frequency from a parameter and stamps scan lines with receive time.
 
-#### Distinguishing the beams (down / port / starboard)
+#### The sub-header varints: v1 bottom range, v2 display range, v3
 
-Diffing the three channels' sub-headers within one range/time window
-(2026-06-10, byte 13 = `0x13`):
-
-| offset | port (ch0) | stbd (ch1) | down (ch2) | note |
-|-------:|:----------:|:----------:|:----------:|------|
-| 8 | `0e` | `0e` | **`0d`** | beam type — separates **down vs side-scan** only |
-| 9–11 | `01 03 09` | `01 03 09` | `01 03 09` | constant |
-| **12** | **`00`** | **`01`** | **`02`** | **channel number** |
-| 13 | `13` | `13` | `13` | range index (same on all channels) |
-| 14… | varint + `19 00 23` | varint + … | varint + … | per-ping range varint (down-look = bottom range); whether the side-scan value is meaningful is open |
-| (after) | `be 93 06` | `be 93 06` | `c4 fa 02` | further sub-header / start of render data |
-
-So:
-
-- **Down vs side-scan** is intrinsic at **offset 8** (`0x0d` down vs
-  `0x0e`/`0x0f` side). (The `0x0e`/`0x0f` split is generation, not side.)
-- **Port vs starboard:** in this capture the two side-scan channels are
-  byte-for-byte identical in the sub-header **except the channel number at
-  offset 12** — no other byte separates them here. The driver therefore maps
-  side from the channel number via the `port_channels` / `stbd_channels` params.
-  Whether an intrinsic side marker exists elsewhere (other offsets not examined,
-  the render payload, or a different capture) is **not yet established**; note
-  only that the channel→side mapping itself differs by generation (GCV-20
-  `0/1/2` vs the GCV-10 survey `3/1`).
-
-#### Byte 13 is a range/scale index, not a generation tag
-
-`decode.py` historically read offset 13 as a GCV-10-vs-GCV-20 "generation tag"
-(`0x11`→gcv10, `0x12`→gcv20). **The 2026-06-10 data disproves this** — that
-assertion was an over-eager guess, not a verified fact:
-
-- On a single GCV-20, byte 13 takes **`0x11`, `0x12`, and `0x13`** purely as a
-  function of range — identical on all three channels, stepping at the auto-range
-  transitions (`0x13` ≈ 19 m display / `0x12` ≈ 14 m / `0x11` shallowest,
-  recovery-only).
-- The **GCV-10** survey fixture reads byte 13 = **`0x13`** — the *same* value a
-  GCV-20 produces in deep water. A value shared across generations cannot be a
-  generation tag.
-
-So byte 13 is the **coarse range bracket** (higher = longer range), one of two
-range controls — the other is the per-ping bottom-range varint below. It is an
-index, so converting it to metres needs a calibrated ladder (only `0x11`–`0x13`
-seen so far; a TCP range-sweep would map the rest).
-
-Why `decode.py`'s old byte-13 detection was broken: in `auto` mode the node
-*waited* (emitting nothing) until `0x12`/`0x11` resolved, so a GCV-20 in deep
-water (`0x13`) stayed silent until a `0x12` ping, and a shallow one (`0x11`)
-mislatched `gcv10`. **Fixed** — detection now uses the structural layer-count
-test below (`decode.generation_from_layers`, voted over a few packets in the
-node), which classifies every packet regardless of range.
-
-#### Generation is recoverable from packet structure (range-independent)
-
-The real GCV-10/GCV-20 difference is **structural**, in the render layers — and
-it is independent of range:
-
-| generation | render layers | later-layer (`SH`/`SHS`) headers | echo | samples |
-|------------|---------------|----------------------------------|------|---------|
-| **GCV-10** | 3 | **2** | last ("dark") layer | 8-bit (`UINT8`) |
-| **GCV-20** | ≤2 | **0 or 1** | first (`FH`) layer | 16-bit LE (`UINT16`) |
-
-Verified: every GCV-10 fixture packet has two later-layer headers `(1,2)`; every
-GCV-20 packet (fixture *and* the 06-10 bag, at **both** byte-13 ranges) has at
-most one `(1,0)`/`(1,1)`. So a packet can be classified **per-packet by counting
-its `SH`/`SHS` headers (≥2 → GCV-10, ≤1 → GCV-20)** — no external generation
-knowledge, and immune to the range-coupling that makes byte 13 unusable for this.
-This is implemented as `decode.generation_from_layers()` and used by the node's
-`auto` device-detect (voted over a few packets). (GCV-10 evidence is one
-16-packet fixture; widen before relying on it.)
-
-#### Range has two controls: the byte-13 bracket + the per-ping bottom-range varint
-
-The full **down-look sub-header** is three LEB128 varints (all in **0.5 mm
-units** — the TCP range command's unit) bracketed by fixed markers. Structure
-verified byte-for-byte on **29,267 packets, 0 mismatches** (`parse_downlook_subheader`):
+The full sub-header is three LEB128 varints (all in **0.5 mm** units)
+bracketed by fixed markers. Structure verified byte-for-byte on **29,267
+packets, 0 mismatches** (`parse_subheader`); the same layout is present on
+every channel:
 
 ```
 08: 0d 01 03 09   beam (0d=down) + const
@@ -260,123 +171,167 @@ verified byte-for-byte on **29,267 packets, 0 mismatches** (`parse_downlook_subh
 13: <bracket>     coarse range index (byte 13, above)
 14: v1  ───────── BOTTOM RANGE   (depth; 7.1–19.9 m; corr 1.00 / ratio 1.013 vs M3)
     19 00 23      marker
-    v2  ───────── DISPLAY RANGE  (scan extent; 10.8–24.2 m; corr 0.99)
+    v2  ───────── DISPLAY RANGE  (scan extent; tracks hardware auto-range)
     2a            marker
     v3  ───────── ~88–99 mm      (near-field / start range?; corr 0.94; meaning TBD)
     31 02 3f      const
     da 04 d8 04   FH header → samples begin
 ```
 
-- **v1 = measured bottom depth**, per ping, and **shared across all channels**
-  (the boat's depth; near-exact vs M3 — *not* the held/laggy `0xe4` value).
-- **v2 = this channel's display range** — the auto-ranged scan extent, and it is
-  **per channel**: on the down-look it is the water-column depth range (e.g.
-  24.2 m, with `v1/v2 ≈ 0.79` so the bottom sits ~79 % down); on the side-scan it
-  is the across-track slant range (~50 m, ~2× the water column). So
-  **`bin_size = v2 / n_bins`** must use the matching channel's v2 (no bottom
-  detection, no ladder, no M3 — `tools/sidescan_waterfall.py` uses exactly this).
-  The same sub-header layout (and the structural markers) is present on every
-  channel; only the channel/layer bytes and v2/v3 differ.
+- **v1 = measured bottom range**, per ping, **shared across all channels**
+  (the boat's depth; near-exact vs M3). The driver publishes it as
+  `~/nadir_depth` (issues #16/#35).
+- **v2 = this channel's own display range** — the auto-ranged scan extent,
+  **per channel**: on the down-look it is the water-column depth range; on the
+  side-scan it is the across-track slant range (~2×). So
+  **`bin_size = v2 / n_bins`** must use the matching channel's v2 — no bottom
+  detection, no calibration ladder, no M3. Verified to track **both** Cod Rock
+  auto-range transitions (side-scan 47.8 → 30.4 → 50.4 → 29.8 → 48.9 m at
+  t≈153/202/561/592 s, 2026-06-10) in lockstep with the byte-13 bracket while
+  the driver's commanded mirror held `60.0`. The driver derives the published
+  `RawSonarImage.sample_rate` from it (#35).
 - **v3 ≈ 96 mm**, weakly depth-correlated — a candidate near-field/blanking or
-  start-range term (possibly the residual sonar-vs-M3 offset).
+  start-range term (§6).
 
-byte 13 is the coarse bracket that gates which range band v2 lives in; v2 is the
-actual per-ping range. `n_bins` (~2034) is **not** a range control — its short
-values (848/1148/1500/1748 ≈ 2034 − N×309) are dropped-packet assembly artifacts.
-(Verify with `.agent/scratchpad/gcv_re.py varint`.)
+byte 13 is the coarse bracket that gates which range band v2 lives in; v2 is
+the actual per-ping range. `n_bins` (~2034) is **not** a range control — its
+short values (848/1148/1500/1748 ≈ 2034 − N×309) are dropped-packet assembly
+artifacts.
 
-### 3.2 Channel marker — `d807` (`239.254.2.1:50220`)
+#### Distinguishing the beams (down / port / starboard)
 
-15–16 byte delimiter emitted between channel runs. Payload `02 <bracket> <v1…>`
-— it echoes the following `eb07` sub-header's range bracket + bottom-range varint
-([pattern D](#d-the-d807-marker-echoes-the-pings-range-fields)). The assembler
-treats it as "flush the current channel's accumulation."
+Diffing the three channels' sub-headers within one range/time window
+(2026-06-10):
 
-### 3.3 Keepalive — `d107` (`239.254.2.1:50220`)
+| offset | port (ch0) | stbd (ch1) | down (ch2) | note |
+|-------:|:----------:|:----------:|:----------:|------|
+| 8 | `0e` | `0e` | **`0d`** | beam type — separates **down vs side-scan** only |
+| 9–11 | `01 03 09` | `01 03 09` | `01 03 09` | constant |
+| **12** | **`00`** | **`01`** | **`02`** | **channel number** |
+| 13 | `13` | `13` | `13` | range index (same on all channels) |
 
-22-byte frame, ~1 Hz, from the chartplotter master. Sustains pinging (the GCV
-will not run without the master's hardware enable + keepalive). Payload
-`04 01 03 0d <chartplotter node id> 12 8a 18 19 03` — the node-descriptor shape
-of [pattern C](#c-a-recurring-node-descriptor-n-01-03-0d-5-byte-node-id). Body
-after the id (`12 8a 18 19 03`) is not decoded; not needed (the driver does not
-synthesize keepalives — it relies on the real chartplotter).
+- **Down vs side-scan** is intrinsic at **offset 8** (`0x0d` down vs
+  `0x0e`/`0x0f` side; the `0x0e`/`0x0f` split is generation, not side).
+- **Port vs starboard:** the two side-scan channels are byte-for-byte
+  identical in the sub-header **except the channel number at offset 12**, so
+  the driver maps side from the channel number via the `port_channels` /
+  `stbd_channels` params. Whether an intrinsic side marker exists elsewhere is
+  **not established**; the channel→side mapping differs by generation (GCV-20
+  `0/1/2` vs the GCV-10 survey `3/1`).
 
-### 3.4 Status — `8e03` (`239.254.2.2:50050`) — tx flag + an undeciphered sub-type
+#### Byte 13 is a range/scale index, not a generation tag
 
-Fixed 34 bytes. The stream interleaves **two sub-types**, discriminated by the
-payload byte at **offset 9** (`0x00` or `0xe4` in the capture; the two are
-emitted concurrently, not tied to a phase). Shared frame:
+`decode.py` historically read offset 13 as a GCV-10-vs-GCV-20 "generation
+tag". The 2026-06-10 data disproves this: on a single GCV-20, byte 13 takes
+`0x11`/`0x12`/`0x13` purely as a function of range — identical on all three
+channels, stepping at the auto-range transitions — and the GCV-10 survey
+fixture reads `0x13`, the same value a GCV-20 produces in deep water. A value
+shared across generations cannot be a generation tag. It is the **coarse range
+bracket** (higher = longer range); converting it to metres would need a
+calibrated ladder (only `0x11`–`0x13` seen; §6).
+
+#### Generation is recoverable from packet structure (range-independent)
+
+The real GCV-10/GCV-20 difference is **structural**, in the render layers, and
+independent of range:
+
+| generation | render layers | later-layer (`SH`/`SHS`) headers | echo | samples |
+|------------|---------------|----------------------------------|------|---------|
+| **GCV-10** | 3 | **2** | last ("dark") layer | 8-bit (`UINT8`) |
+| **GCV-20** | ≤2 | **0 or 1** | first (`FH`) layer | 16-bit LE (`UINT16`) |
+
+Verified: every GCV-10 fixture packet has two later-layer headers; every
+GCV-20 packet (fixtures *and* the 06-10 bag, at both byte-13 ranges) has at
+most one. So a packet is classified **per-packet by counting its `SH`/`SHS`
+headers (≥2 → GCV-10, ≤1 → GCV-20)** — implemented as
+`decode.generation_from_layers()`, voted over a few packets by the node's
+`auto` device-detect. (GCV-10 evidence is one 16-packet fixture; widen before
+relying on it.)
+
+### 4.2 Channel marker — `d807`
+
+14–16 byte delimiter emitted between channel runs; payload decoded in
+[§3.C](#c-the-d807-marker-channel-tag--current-range-measurement). The
+assembler treats it as "flush the current channel's accumulation."
+
+### 4.3 Keepalive — `d107`
+
+22-byte frame, exactly 1 Hz, from the chartplotter master. Sustains pinging
+(the GCV will not run without the master's hardware enable + keepalive).
+Payload `04 01 03 0d <chartplotter node id> 12 8a 18 19 03` — the node
+descriptor of §3.A; byte-identical across the full 2026-06-11 capture. The
+body after the id is not decoded; not needed (the driver does not synthesize
+keepalives — it relies on the real chartplotter).
+
+### 4.4 Status — `8e03` (`239.254.2.2:50050`)
+
+Fixed 34 bytes. The stream multiplexes **sub-types**, discriminated by the
+payload byte at **offset 9**. Shared frame:
 
 | offset | bytes | meaning |
 |-------:|-------|---------|
-| 0–3 | `8e 03 00 00` | magic + pad |
+| 0–3 | `8e 03 00 00` | id + zero high half |
 | 4–7 | `1a 00 00 00` | LE length (26) |
 | 8 | `02` | constant |
-| **9** | `00` \| `e4` | **sub-type discriminator** |
+| **9** | sub-type | `0x00`/`0x01` settings echo (+ tx flag), `0xe4` held value, rare one-shots below |
 | 10–16 | `0a 0c 00 00 03 01 00` | constant |
-| 17–23 | *sub-type specific* | `0xe4` value (below) or settings echo |
+| 17–23 | *sub-type specific* | |
 | 24–29 | `e0 a0 91 0b 01 04` | constant device/message tail |
-| 30–31 | u16 LE | monotonic counter (uptime/sequence, ~1/frame) |
+| 30–31 | u16 LE | monotonic counter |
 | 32–33 | `00 00` | constant |
 
-Constant region confirmed byte-for-byte across all 124 `0x00` + 91 `0xe4`
-frames; only offsets 17–23, the 30–31 counter, and byte 9 vary.
+Constant regions verified byte-for-byte on every status frame of both wet
+captures (215 + 359 frames).
 
-**Sub-type `0xe4` — a held value of unconfirmed meaning (NOT depth):**
+**Sub-type `0x00` / `0x01` — settings echo and transmit flag.** `0x00` =
+transmitting, `0x01` = off (the only sub-types the driver reads —
+`decode.status_transmitting`; all others return "unknown" so they cannot flap
+the flag). Offsets 17–23 = `ae 05 c0 75 ae 05 c0`, **constant** through both
+captures including the auto-range transitions — a stale commanded/configured
+echo, NOT the active range. Field decode unconfirmed and not needed.
 
-```
-offset 17 18 19 | 20 21 | 22 23
-        00 00 00 | VV VV | 00 00      value = u16_LE(20)  (offsets 17-19/22-23 = 00)
-```
+**Sub-type `0xe4` — a held value of unconfirmed meaning (NOT depth).** A u16
+LE at offset 20 (offsets 17–19/22–23 zero). Cross-checked against the M3: it
+is **held** for tens of seconds, lags the M3 nadir by 2–7 m, and does not
+track the bottom — its earlier reading as a nadir depth is disproven (#16
+history). The real per-ping bottom range is the imagery sub-header **v1**
+(§4.1), which the driver publishes as `~/nadir_depth`.
 
-The offset-20 `u16` is **not a depth**: it is **held** (one value for tens of
-seconds), lags the M3 nadir by 2–7 m, and does not track the bottom (it only
-*looked* depth-like because its mean and Cod-Rock dips happened to align). Its
-meaning is unconfirmed — likely a mode/status field. The driver does **not**
-decode or publish it. The real per-ping bottom range is instead the **down-look
-imagery sub-header v1** (§3.1, offset-14 varint, M3-validated), which the
-driver publishes as `~/nadir_depth` (issues #16/#35); draft/tide/offset
-correction is a downstream concern.
+**Rare one-shot sub-types** (2026-06-11 capture, one frame each — meaning
+unknown, §6):
 
-**Sub-type `0x00` — settings echo (NOT the active range):**
+| t (s) | byte 9 | offsets 16–23 | shape |
+|------:|--------|----------------|-------|
+| 419.6 | `0x09` | `00 53 8e 3a 55 4c cf 3a` | two small float32-like values? |
+| 679.9 | `0x1f` | `00 16 86 3c 9f 8a d8 3c` | same shape as `0x09` |
+| 1005.1 | `0xed` | `00 00 00 00 94 89 00 00` | same zeros+u16@20 shape as `0xe4` |
 
-Offsets 17–23 = `ae 05 c0 75 ae 05 c0`, **constant** the entire capture
-including both Cod Rock auto-range transitions. This is the **stale
-commanded/configured** value (it matches the driver's `state` holding
-`range: 60.0` while the hardware auto-ranged underneath). Exact field decode of
-the repeated `ae 05 c0` is unconfirmed and not needed.
-
-### 3.5 Config — `e708` heartbeat + `e508` records (`239.254.2.11:51000`)
+### 4.5 Config — `e708` heartbeat + `e508` records (`239.254.2.11:51000`)
 
 The chartplotter's CDP config broadcast (it owns range/freq/schedule on the
-bus). Two frames:
+bus):
 
-- **`e708` (19 B, ~1 Hz)** — device-id heartbeat:
-  `03 01 03 0d 90 db a2 88 0b 11 01` (node descriptor + `11 01`). Static.
-- **`e508` (168 / 173 B, in bursts)** — named ping-schedule records, CDP TLV
-  ([pattern E](#e-cdp-named-tlv--leb128-values)). Four record kinds seen
+- **`e708` (19 B, 1 Hz)** — static device-id heartbeat:
+  `03 01 03 0d 90 db a2 88 0b 11 01` (§3.A).
+- **`e508` (168 / 173 B, in bursts)** — named ping-schedule records, ASCII-keyed
+  TLV: `<tag> <len> <key-ascii> 00 <value-record> …` closing with a
+  `2f 08`-tagged LEB128 timestamp. Four record kinds seen
   (`yutl-port/stbd/cntr-port/cntr-stbd-engn-sched`), each carrying nested keys
-  `yutl-engn-sched-type`, `stnd-sched`, `opt-sched-1/2/3` and a trailing
-  `2f 08 <LEB128 timestamp>`.
+  `yutl-engn-sched-type`, `stnd-sched`, `opt-sched-1/2/3`.
 
-**Important (issues #32/#35):** across the full capture the **only** changing
-bytes in any config frame are the port/stbd string label and the per-frame
-timestamp tail. **No range field, nothing steps at the Cod Rock auto-range
-transitions.** The active range is *not* on this stream — but it **is**
-passively available after all: each channel's per-ping sub-header **v2**
-(§3.1) is that channel's true active display range, verified to track both
-Cod Rock auto-range transitions in lockstep with the byte-13 bracket
-(side-scan 47.8 → 30.4 → 50.4 → 29.8 → 48.9 m at t≈153/202/561/592 s) while
-the driver's commanded mirror held `60.0`. The driver derives the published
-``RawSonarImage.sample_rate`` from it (#35), so consumers recover the true
-per-ping range. Pinning/disabling auto-range over the command port (#32
-deliverable B) remains open as an optional survey-ops capability — for
-*holding* a fixed swath, no longer for *knowing* it.
+**Important (issues #32/#35):** across the full 06-10 capture the **only**
+changing bytes in any config frame are the port/stbd string label and the
+per-frame timestamp tail. **No range field, nothing steps at the Cod Rock
+auto-range transitions.** The active range is *not* on this stream — but it
+**is** passively available: each channel's per-ping sub-header **v2** (§4.1)
+is that channel's true active display range. The driver derives the published
+`RawSonarImage.sample_rate` from it (#35). Pinning/disabling auto-range over
+the command port (#32 deliverable B) remains open as an optional survey-ops
+capability — for *holding* a fixed swath, no longer for *knowing* it.
 
-### 3.6 Command — `d2 07 ef be` (TCP `172.16.3.0:50227`, outbound)
+### 4.6 Command — id `0xBEEF07D2` (TCP `172.16.3.0:50227`, outbound)
 
-The driver's control path (from `commands.py`). 4-byte magic + `uint32 LE
-length` + payload. Builders:
+The driver's control path (from `commands.py`; envelope in §1). Builders:
 
 | Command | Payload shape | Notes |
 |---------|---------------|-------|
@@ -386,48 +341,42 @@ length` + payload. Builders:
 | Interference | `01 07 07 01 02 01 00 a1 01 <0-3>` | off/low/medium/high |
 
 **Gap (issue #32 deliverable B):** there is **no** auto-range-disable /
-force-manual-range builder yet — needed to hold a fixed swath against the
+force-manual-range builder — needed only to hold a fixed swath against the
 chartplotter's auto-range.
 
 ---
 
-## 4. Ground-truth method (M3 multibeam)
+## 5. Ground-truth method (M3 multibeam)
 
 Decodes that needed a depth/bathymetry reference were checked against the M3
 multibeam in the same sonar bag (same gabby clock). M3 bottom depth per ping =
 median over beams of `twtt/2 · sound_speed · cos(rx_angle)` (sound_speed ≈ 1498
-m/s from `ping_info`). Boat position is in `/bizzy/odom` — used to locate the two
-Cod Rock crossings (the survey lines, ~t174 & ~t561) vs the dock return (end of
-bag). The M3 confirms the bin-size ladder and bottom-range varint (§3.1) and
-disproved the `0xe4`-as-depth reading (§3.4).
+m/s from `ping_info`). Boat position is in `/bizzy/odom` — used to locate the
+two Cod Rock crossings vs the dock return. The M3 confirms the sub-header v1
+bottom range and v2 scaling (§4.1) and disproved the `0xe4`-as-depth reading
+(§4.4).
 
 ---
 
-## 5. Open questions
+## 6. Open questions
 
-- **Imagery sub-header varints (down-look).** Offset-14 = per-ping bottom range
-  in ~0.5 mm units (§3.1). The down-look sub-header is fully parsed (v1 bottom
-  range, v2 display range, v3 ≈ near-field) and the side-scan carries the same
-  structure with its own v2; **v3's meaning (~0.1 m, weakly depth-coupled) is
-  still open**.
-- **Byte 13 → metres.** Only `0x11`–`0x13` seen; a TCP range-sweep would map the
-  full bracket ladder to metres. (Generation detection no longer uses byte 13 —
-  now structural, §3.1.)
-- **`0xe4` sub-type value** — not depth (§3.4); meaning open. A `:50050` capture
-  across known device states would decipher it.
+- **v3** (~0.1 m, weakly depth-coupled) — near-field/blanking/start-range?
+- **Byte 13 → metres.** Only `0x11`–`0x13` seen; a TCP range-sweep would map
+  the full bracket ladder.
+- **`0xe4` value** — held, not depth; meaning open. **New 2026-06-11:**
+  one-shot sub-types `0x09`/`0x1f` (float-pair-like) and `0xed` (same shape as
+  `0xe4`) — a `:50050` capture across known device state changes (transmit
+  on/off, range commands, frequency switch) would decipher the family.
+- **`d807` 16-byte sub-form** (`02 0c … 41 19 <ch>`, ~1.2 % of markers) —
+  inner layout unknown.
+- **`0xBEEF` command high half** — required by the device, or cosmetic? One
+  TCP experiment (send a `0x0000`-high command); don't test on a live survey
+  unit.
 - **Gain coupled to the range bracket.** Raw sample brightness *steps* at each
-  byte-13 transition (higher gain at short range `0x12`, lower at long range
-  `0x13`) — a range-coupled TVG/AGC the device applies before sending samples.
-  Whether a separate gain field is encoded (vs. implied by the bracket) is open.
-  The driver publishes samples as-is; any gain normalization is a downstream
-  concern.
-- **`00 00` after every magic** — high half of a 32-bit id, or reserved?
+  byte-13 transition (higher gain at short range) — a range-coupled TVG/AGC
+  applied before sending samples. Whether a separate gain field exists is
+  open. The driver publishes samples as-is; gain normalization is a
+  downstream concern.
 - **Node id bodies** (`90 db a2 88 0b`, `d5 a7 f2 8b 0d`), **`e508` value
   records**, and the **`0x00`-status settings block** (`ae 05 c0 …`) — field
   decodes unknown; not yet needed.
-- ~~**Nadir depth**~~ — **resolved (#16/#35)**: the device *does* report a real
-  per-ping bottom range — the sub-header **v1** varint (§3.1, M3-validated to
-  ~1%) — and the driver publishes it as a downward `sensor_msgs/Range` on
-  `~/nadir_depth`. (The earlier `0xe4`-status reading remains disproven, §3.4.)
-  Draft/tide/transducer-offset correction is a downstream concern, not the
-  driver's.

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -293,8 +293,10 @@ keepalives — it relies on the real chartplotter).
 ### 4.4 Status — `8e03` (`239.254.2.2:50050`)
 
 Fixed 34 bytes **from the GCV**. (The chartplotter broadcasts its own
-**70-byte** `8e03` variant on the same group — see §4.7; boat-side bags have
-only ever shown the 34-byte GCV frames.) The stream multiplexes
+**70-byte** `8e03` variant on the same group — see §4.7; boat-side bags never
+show it because the Marine-Network **proxy deliberately filters `:50050` to
+the GCV's source IP** — `tools/garmin_marine_network_proxy.py`. Relaying the
+chartplotter frames too would need a proxy option.) The stream multiplexes
 **sub-types**, discriminated by the payload byte at **offset 9**. Shared
 frame:
 

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -30,7 +30,15 @@ with their receive time (see node.py).
 """
 from collections import namedtuple
 
+# Frame ids (low half of the u32-LE message id; the high half is 0x0000 on
+# every bus frame, so they read as "<magic> 00 00" -- see docs/gcv_protocol.md
+# section 1 for the envelope).
 EB07 = b'\xeb\x07'
+# Channel marker. Payload `02 <bracket> <v1 varint> 19 <channel>` -- it names
+# the channel whose run it delimits and carries the current range measurement
+# (verified 2026-06-11; see gcv_protocol.md section 3.C). The assembler only
+# uses it as a flush signal: the run's own eb07 sub-headers carry the same
+# fields authoritatively.
 D807 = b'\xd8\x07'
 STATUS_MAGIC = b'\x8e\x03'       # GCV status broadcast (239.254.2.2:50050)
 # The :50050 stream multiplexes two 34-byte sub-types, discriminated by the
@@ -52,6 +60,11 @@ STATUS_MAGIC = b'\x8e\x03'       # GCV status broadcast (239.254.2.2:50050)
 # The real per-ping bottom range is instead carried in the imagery sub-header
 # (v1, :func:`parse_subheader`) -- M3-validated -- and the driver publishes it
 # as ``~/nadir_depth``.
+#
+# The 2026-06-11 capture also shows RARE one-shot sub-types (0x09, 0x1f, 0xed
+# -- one frame each; meanings unknown, see gcv_protocol.md section 4.4).
+# status_transmitting() returns None for every sub-type other than 0x00/0x01,
+# so unknown sub-types can never flap the transmit flag.
 STATUS_SUBTYPE_OFFSET = 9
 STATUS_TX_OFFSET = STATUS_SUBTYPE_OFFSET     # legacy alias (tx flag == sub-type byte)
 STATUS_SUBTYPE_SETTINGS = 0x00

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -34,11 +34,11 @@ from collections import namedtuple
 # every bus frame, so they read as "<magic> 00 00" -- see docs/gcv_protocol.md
 # section 1 for the envelope).
 EB07 = b'\xeb\x07'
-# Channel marker. Payload `02 <bracket> <v1 varint> 19 <channel>` -- it names
-# the channel whose run it delimits and carries the current range measurement
-# (verified 2026-06-11; see gcv_protocol.md section 3.C). The assembler only
-# uses it as a flush signal: the run's own eb07 sub-headers carry the same
-# fields authoritatively.
+# Channel marker. Payload `02 <field2 tag + v1 varint> 19 <channel>` -- a
+# two-field record tagging an adjacent run's channel and carrying that run's
+# bottom range (markers bracket runs in close/open pairs; see gcv_protocol.md
+# section 3.C). The assembler only uses it as a flush signal: the run's own
+# eb07 sub-headers carry the same fields authoritatively.
 D807 = b'\xd8\x07'
 STATUS_MAGIC = b'\x8e\x03'       # GCV status broadcast (239.254.2.2:50050)
 # The :50050 stream multiplexes two 34-byte sub-types, discriminated by the
@@ -135,19 +135,13 @@ LEADING_RUN_MIN_BYTES = 24           # >=12 repeated uint16 samples
 
 CHANNEL_OFFSET = 12
 # Render-layer byte at offset 8 also encodes the beam TYPE: the
-# down-look ("water column") beam is 0x0d on both generations, while side-scan
+# down-look ("water column") beam is 0x0d on both generations (verified on the
+# GCV-20 wet captures AND the 2026-06-05 GCV-10 bench capture, where the
+# auto-ranging down channel reads 0x0d), while side-scan
 # (sidescan) is 0x0e (GCV-20) / 0x0f (GCV-10). So the down-look stream is
 # identifiable intrinsically, independent of channel number or packet size.
 LAYER_OFFSET = 8
 WATER_COLUMN_LAYER = 0x0d
-# DEPRECATED: byte 13 was once read as a generation tag (0x11=GCV-10, 0x12=GCV-20),
-# but the 2026-06-10 capture disproved that -- it is the RANGE BRACKET
-# (:data:`RANGE_BRACKET_OFFSET` below; a GCV-20 shows 0x11/0x12/0x13 by range,
-# and the GCV-10 fixture shows 0x13 too). Generation is detected structurally
-# instead -- see :func:`generation_from_layers`. These constants are retained only
-# for reference / back-compat; do NOT use them to detect generation.
-GEN_TAG_OFFSET = 13             # == RANGE_BRACKET_OFFSET (range bracket, not gen)
-GEN_BY_TAG = {0x11: 'gcv10', 0x12: 'gcv20'}
 MIN_DATA_LEN = 32               # below this an eb07 payload has no sample data
 # A real scan line is ~2048 bins; cap the accumulator so a degenerate stream
 # (one channel forever, no markers) can't grow it without bound.
@@ -283,8 +277,10 @@ def is_water_column(payload):
 
 
 # eb07 sub-header range fields (see docs/gcv_protocol.md).
-RANGE_BRACKET_OFFSET = 13         # coarse range-bracket index (shared by all channels)
-RANGE_VARINT_OFFSET = 14          # down-look per-ping bottom-range LEB128 varint
+# The sub-header is a tagged record: tag byte = (field# << 3) | varint_length,
+# fields 2..5 in order after the field-1 channel tag (0x09) at offset 11.
+V1_TAG_OFFSET = 13                # field-2 tag (0x10 | len(v1)); ex-"range bracket"
+RANGE_VARINT_OFFSET = 14          # per-ping bottom-range LEB128 varint (v1)
 RANGE_UNIT_M = 0.0005             # 0.5 mm units (matches the TCP range command)
 
 
@@ -327,45 +323,61 @@ def subheader_bottom_range_m(payload):
     return raw * RANGE_UNIT_M
 
 
-# Imagery sub-header: three LEB128 varints (0.5 mm units) with fixed markers,
-# the same layout on every channel --
-#   <layer> 01 03 09 <chan> <bracket> | v1 | 19 00 23 | v2 | 2a | v3 | 31 02 3f | FH…
-# (verified on 29k+ packets; see docs/gcv_protocol.md).
-#   v1 = measured bottom range/depth -- SHARED across channels (the boat's depth);
-#   v2 = this channel's display range/scan extent -- down-look = water-column
-#        depth range, side-scan = across-track slant range (~2x), so
-#        bin_size = v2 / n_bins is PER CHANNEL;
-#   v3 = a small near-field/start term (~0.1 m), per channel, meaning unconfirmed.
+# Imagery sub-header: a tagged record (docs/gcv_protocol.md section 3):
+#
+#   tag byte = (field# << 3) | L,  L = the value's LEB128 byte length
+#
+#   <layer> 01 03 | 09 <chan> | 0x10|L v1 | 0x18|L f3 | 0x20|L v2 | 0x28|L v3 | 31 02 3f | FH…
+#            └ field0 = 3 ┘ field1      field2       field3      field4      field5     field6
+#
+# Grammar verified with zero exceptions on 697k+ frames across five captures
+# and both generations (the byte once read as a "range bracket" -- and before
+# that as a "generation tag" -- is field2's tag: its low bits step when the
+# bottom range crosses the 1/2/3-byte varint boundaries at 4.10 m / 8.19 m).
+#   v1 (field2) = measured bottom range -- SHARED across channels;
+#   v2 (field4) = this channel's display range/scan extent -- down-look =
+#        water-column depth range (always auto), side-scan = across-track
+#        slant range (= the commanded range when one is set, verified against
+#        an operator range sweep), so bin_size = v2 / n_bins is PER CHANNEL;
+#   v3 (field5) = a small near-field/start term (~0.1 m), meaning unconfirmed.
 Subheader = namedtuple(
-    'Subheader', 'channel layer bracket bottom_range_m display_range_m near_field_m')
+    'Subheader', 'channel layer v1_tag bottom_range_m display_range_m near_field_m')
 
 
 def parse_subheader(payload):
     """
-    Parse an eb07 imagery sub-header (any channel), or return None.
+    Parse an eb07 imagery sub-header (any channel, any generation), or None.
 
-    Returns a :class:`Subheader`. ``display_range_m`` (v2) is this channel's own
-    scan extent -- water-column depth range on the down-look, across-track slant
-    range on the side-scan -- so bin size = ``display_range_m / n_bins`` must use
-    the matching channel. ``bottom_range_m`` (v1) is the shared bottom depth.
-    Validates the fixed markers (``01 03 09`` / ``19 00 23`` / ``2a``) so a
-    garbled payload yields None.
+    Walks the tagged-record grammar: each field is ``(field# << 3) | L`` with
+    an L-byte LEB128 value; fields 2..5 must appear in order with matching
+    lengths, so a garbled payload yields None. Returns a :class:`Subheader`:
+    ``display_range_m`` (v2) is this channel's own scan extent -- water-column
+    depth range on the down-look, across-track slant range on the side-scan --
+    so bin size = ``display_range_m / n_bins`` must use the matching channel;
+    ``bottom_range_m`` (v1) is the shared bottom range; ``v1_tag`` is field2's
+    raw tag byte (``0x10 | len(v1)``, the ex-"range bracket").
     """
     if (payload[:2] != EB07 or len(payload) < 33
             or payload[9:12] != b'\x01\x03\x09'):
         return None
-    v1, o = decode_leb128(payload, RANGE_VARINT_OFFSET)
-    if v1 is None or payload[o:o + 3] != b'\x19\x00\x23':
-        return None
-    v2, o = decode_leb128(payload, o + 3)
-    if v2 is None or o >= len(payload) or payload[o] != 0x2a:
-        return None
-    v3, _ = decode_leb128(payload, o + 1)
-    if v3 is None:
-        return None
+    vals = {}
+    i = V1_TAG_OFFSET
+    for want_field in (2, 3, 4, 5):
+        if i >= len(payload):
+            return None
+        tag = payload[i]
+        length = tag & 0x07
+        if tag >> 3 != want_field or not 1 <= length <= 6:
+            return None
+        value, end = decode_leb128(payload, i + 1)
+        if value is None or end - (i + 1) != length:
+            return None
+        vals[want_field] = value
+        i = end
     return Subheader(payload[CHANNEL_OFFSET], payload[LAYER_OFFSET],
-                     payload[RANGE_BRACKET_OFFSET],
-                     v1 * RANGE_UNIT_M, v2 * RANGE_UNIT_M, v3 * RANGE_UNIT_M)
+                     payload[V1_TAG_OFFSET],
+                     vals[2] * RANGE_UNIT_M, vals[4] * RANGE_UNIT_M,
+                     vals[5] * RANGE_UNIT_M)
 
 
 def parse_downlook_subheader(payload):
@@ -388,7 +400,7 @@ def derive_sample_rate(sub, n_bins, sound_speed, commanded_range_m=0.0,
     2. **The commanded range** (``commanded_range_m``) -- correct only while
        the device honours it, and never correct for the down-look (whose v2
        is the water-column range, not the commanded swath); kept as a
-       fallback for streams whose sub-header does not parse (e.g. GCV-10).
+       fallback for garbled packets whose sub-header fails to parse.
     3. **``fallback_rate``** -- a manually configured rate, or 0.0 =
        "unavailable" (the ``RawSonarImage`` convention).
 
@@ -405,7 +417,7 @@ def derive_sample_rate(sub, n_bins, sound_speed, commanded_range_m=0.0,
 
 # One assembled scan line.  ``stamp`` is the ``recv_time`` of the run's first
 # packet; ``subheader`` is that run's parsed :class:`Subheader` (None when no
-# packet of the run parsed -- e.g. the GCV-10 layout, see test fixtures).
+# packet of the run parsed -- both generations parse; see test fixtures).
 ScanLine = namedtuple('ScanLine', 'channel samples stamp subheader')
 
 

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -49,8 +49,9 @@ STATUS_MAGIC = b'\x8e\x03'       # GCV status broadcast (239.254.2.2:50050)
 # showed it is a HELD, coarse value that does NOT track depth (it lags by tens
 # of seconds and sits metres off the M3 nadir) -- so its meaning is unconfirmed
 # (a candidate mode/status field) and the driver does NOT decode or publish it.
-# A real nadir depth, if wanted, comes from bottom-tracking the down-look
-# imagery in a downstream node, not from this field.
+# The real per-ping bottom range is instead carried in the imagery sub-header
+# (v1, :func:`parse_subheader`) -- M3-validated -- and the driver publishes it
+# as ``~/nadir_depth``.
 STATUS_SUBTYPE_OFFSET = 9
 STATUS_TX_OFFSET = STATUS_SUBTYPE_OFFSET     # legacy alias (tx flag == sub-type byte)
 STATUS_SUBTYPE_SETTINGS = 0x00
@@ -361,16 +362,52 @@ def parse_downlook_subheader(payload):
     return parse_subheader(payload)
 
 
+def derive_sample_rate(sub, n_bins, sound_speed, commanded_range_m=0.0,
+                       fallback_rate=0.0):
+    """
+    Return the ``RawSonarImage.sample_rate`` (Hz) for one assembled ping.
+
+    The scale source, in priority order:
+
+    1. **The ping's own sub-header v2** (``sub.display_range_m``) -- the
+       device's per-ping, per-channel display range, which tracks hardware
+       auto-range (verified across the 2026-06-10 Cod Rock transitions).
+    2. **The commanded range** (``commanded_range_m``) -- correct only while
+       the device honours it, and never correct for the down-look (whose v2
+       is the water-column range, not the commanded swath); kept as a
+       fallback for streams whose sub-header does not parse (e.g. GCV-10).
+    3. **``fallback_rate``** -- a manually configured rate, or 0.0 =
+       "unavailable" (the ``RawSonarImage`` convention).
+
+    With a range ``R`` the rate is ``sound_speed * n_bins / (2 * R)``, so a
+    consumer recovers ``R = sound_speed * n_bins / (2 * rate)``.
+    """
+    range_m = sub.display_range_m if sub is not None else 0.0
+    if range_m <= 0.0:
+        range_m = commanded_range_m
+    if range_m > 0.0 and sound_speed > 0.0 and n_bins > 0:
+        return sound_speed * n_bins / (2.0 * range_m)
+    return fallback_rate
+
+
+# One assembled scan line.  ``stamp`` is the ``recv_time`` of the run's first
+# packet; ``subheader`` is that run's parsed :class:`Subheader` (None when no
+# packet of the run parsed -- e.g. the GCV-10 layout, see test fixtures).
+ScanLine = namedtuple('ScanLine', 'channel samples stamp subheader')
+
+
 class PingAssembler:
     """
     Reassemble GCV imagery datagrams into per-channel scan lines.
 
     Feed each UDP payload to :meth:`feed`; it returns a list of completed
-    ``(channel, samples, stamp)`` tuples (usually empty, occasionally one when
-    a channel's run ends).  ``stamp`` is the ``recv_time`` passed with the
+    :class:`ScanLine` tuples (usually empty, occasionally one when a
+    channel's run ends).  ``stamp`` is the ``recv_time`` passed with the
     first packet of that run, so callers can timestamp a scan line by the
-    arrival of its first packet.  Call :meth:`flush` at end of stream to emit
-    any trailing accumulation.
+    arrival of its first packet; ``subheader`` is the run's own parsed
+    sub-header (per-ping v1 bottom range / v2 display range), so callers can
+    scale and depth-tag each ping.  Call :meth:`flush` at end of stream to
+    emit any trailing accumulation.
     """
 
     def __init__(self, extractor=dark_layer):
@@ -380,11 +417,14 @@ class PingAssembler:
         self._cur_ch = None
         self._acc = bytearray()
         self._t0 = 0.0
+        self._cur_sub = None
 
     def _emit(self, out):
         if self._cur_ch is not None and self._acc:
-            out.append((self._cur_ch, bytes(self._acc), self._t0))
+            out.append(ScanLine(self._cur_ch, bytes(self._acc), self._t0,
+                                self._cur_sub))
         self._acc = bytearray()
+        self._cur_sub = None
 
     def feed(self, payload, recv_time=0.0):
         """Consume one datagram payload; return any completed scan lines."""
@@ -403,12 +443,18 @@ class PingAssembler:
                 # scan line, and only on the GCV-20 (echo_layer) stream.
                 if self._extract is echo_layer:
                     block = strip_leading_ping_header(block)
+            if self._cur_sub is None:
+                # Every packet of a run repeats the same sub-header values, so
+                # the first packet that parses tags the whole run (a garbled
+                # first packet falls through to the next).
+                self._cur_sub = parse_subheader(payload)
             self._acc.extend(block)
             if len(self._acc) > MAX_SCAN_BYTES:
                 # Degenerate stream (no channel change, no marker): drop the
                 # runaway accumulation rather than grow without bound.
                 self._acc = bytearray()
                 self._cur_ch = None
+                self._cur_sub = None
         return out
 
     def flush(self):

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -377,11 +377,13 @@ def parse_subheader(payload):
     # Two further invariants, empirically universal on every imagery frame of
     # five captures / both generations (549k+ frames, zero exceptions):
     # field3's value is 0 (it carries a channel only in d807 markers), and
-    # field6 (tag 0x31) immediately follows field5.  Rejecting on them keeps a
-    # partially corrupted header from "parsing" into bogus v1/v2 -- a missing
-    # scale is safe (fallback chain), a wrong scale silently corrupts
-    # everything downstream.
-    if vals[3] != 0 or i >= len(payload) or payload[i] >> 3 != 6:
+    # the exact constant ``31 02 3f`` (field6 = 2 + tail byte) immediately
+    # follows field5.  Rejecting on them keeps a partially corrupted header
+    # from "parsing" into bogus v1/v2 -- a missing scale is safe (fallback
+    # chain), a wrong scale silently corrupts everything downstream.  The
+    # slice compare is bounds-safe: a truncated payload yields a short slice,
+    # which fails the equality and parses as None.
+    if vals[3] != 0 or payload[i:i + 3] != b'\x31\x02\x3f':
         return None
     return Subheader(payload[CHANNEL_OFFSET], payload[LAYER_OFFSET],
                      payload[V1_TAG_OFFSET],

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -374,6 +374,15 @@ def parse_subheader(payload):
             return None
         vals[want_field] = value
         i = end
+    # Two further invariants, empirically universal on every imagery frame of
+    # five captures / both generations (549k+ frames, zero exceptions):
+    # field3's value is 0 (it carries a channel only in d807 markers), and
+    # field6 (tag 0x31) immediately follows field5.  Rejecting on them keeps a
+    # partially corrupted header from "parsing" into bogus v1/v2 -- a missing
+    # scale is safe (fallback chain), a wrong scale silently corrupts
+    # everything downstream.
+    if vals[3] != 0 or i >= len(payload) or payload[i] >> 3 != 6:
+        return None
     return Subheader(payload[CHANNEL_OFFSET], payload[LAYER_OFFSET],
                      payload[V1_TAG_OFFSET],
                      vals[2] * RANGE_UNIT_M, vals[4] * RANGE_UNIT_M,

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -807,11 +807,15 @@ class GarminSidescanNode(Node):
             self._make_sonar_msg(side, line.samples, line.stamp, line.subheader))
         # Nadir bottom range: the per-ping sub-header v1 varint. It is shared
         # across channels (the boat's depth), but published once per ping from
-        # the down-look -- the beam that actually measures it.
+        # the down-look -- the beam that actually measures it. max_range is
+        # the ping's own water-column extent (v2): the sensor's actual
+        # observable window this ping, NOT the side-scan command clamp -- so a
+        # garbled v1 beyond it is spec-discardable (Range: range > max_range).
         if side == 'down' and line.subheader and line.subheader.bottom_range_m > 0.0:
             self._pub_depth.publish(build_nadir_range(
                 line.subheader.bottom_range_m, self._nadir_frame_id,
-                line.stamp.to_msg(), self._nadir_fov, self._range_max))
+                line.stamp.to_msg(), self._nadir_fov,
+                line.subheader.display_range_m))
 
     def _make_sonar_msg(self, side, samples, stamp, sub=None):
         msg = RawSonarImage()
@@ -825,10 +829,15 @@ class GarminSidescanNode(Node):
         # The range source is the ping's OWN sub-header v2 (per channel, tracks
         # hardware auto-range), falling back to the commanded-range mirror and
         # then the sample_rate_hz parameter -- see decode.derive_sample_rate.
+        # The commanded fallback applies to the side-scan only: the down-look's
+        # range is its auto-ranged water-column extent, never the commanded
+        # swath, so a wrong-but-confident ~2x scale must not be published --
+        # better "unavailable" than wrong.
         bins = len(samples) // self._bytes_per_sample
+        commanded = (0.0 if side == 'down'
+                     else float(self._controls.get('range') or 0.0))
         msg.sample_rate = derive_sample_rate(
-            sub, bins, sv,
-            commanded_range_m=float(self._controls.get('range') or 0.0),
+            sub, bins, sv, commanded_range_m=commanded,
             fallback_rate=self._sample_rate)
         msg.samples_per_beam = bins
         msg.sample0 = 0

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -88,8 +88,10 @@ def build_nadir_range(depth_m, frame_id, stamp, field_of_view, max_range):
     down -- NOT the water-column ``_down`` frame, which is Z-down (the marine
     convention the down-look ``RawSonarImage`` uses; see ``docs/gcv_protocol.md``).
     ``min_range`` is 0 so a genuinely shallow reading is not flagged invalid;
-    ``max_range`` bounds it at the configured swath maximum.  ``stamp`` is the
-    ping receive time (the imagery stream carries no transmit clock).
+    ``max_range`` is the ping's own observable window -- the caller passes the
+    down-look sub-header v2 water-column extent, NOT a fixed configured bound.
+    ``stamp`` is the ping receive time (the imagery stream carries no transmit
+    clock).
     """
     msg = Range()
     msg.header.stamp = stamp
@@ -809,13 +811,16 @@ class GarminSidescanNode(Node):
         # across channels (the boat's depth), but published once per ping from
         # the down-look -- the beam that actually measures it. max_range is
         # the ping's own water-column extent (v2): the sensor's actual
-        # observable window this ping, NOT the side-scan command clamp -- so a
-        # garbled v1 beyond it is spec-discardable (Range: range > max_range).
-        if side == 'down' and line.subheader and line.subheader.bottom_range_m > 0.0:
-            self._pub_depth.publish(build_nadir_range(
-                line.subheader.bottom_range_m, self._nadir_frame_id,
-                line.stamp.to_msg(), self._nadir_fov,
-                line.subheader.display_range_m))
+        # observable window this ping, NOT the side-scan command clamp. A
+        # parseable-but-implausible v1 (non-positive, or beyond the window)
+        # is not published at all -- a per-ping gap is honest sensor output,
+        # a spec-invalid Range (range > max_range) is just noise downstream.
+        if side == 'down' and line.subheader:
+            v1, v2 = line.subheader.bottom_range_m, line.subheader.display_range_m
+            if 0.0 < v1 <= v2:
+                self._pub_depth.publish(build_nadir_range(
+                    v1, self._nadir_frame_id, line.stamp.to_msg(),
+                    self._nadir_fov, v2))
 
     def _make_sonar_msg(self, side, samples, stamp, sub=None):
         msg = RawSonarImage()

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -4,7 +4,10 @@ Garmin GCV-10/20 sidescan sonar driver node.
 Receives the GCV imagery multicast, decodes per-ping sidescan scan lines (see
 :mod:`garmin_sidescan.decode`) and publishes them as
 ``marine_acoustic_msgs/RawSonarImage`` (one publisher per channel, single
-beam).  Controls transmit on/off and range over the GCV TCP command port
+beam) with the metric scale (``sample_rate``) derived from each ping's own
+sub-header display range (v2), plus the per-ping nadir bottom range
+(sub-header v1) as a ``sensor_msgs/Range`` on ``~/nadir_depth``.  Controls
+transmit on/off and range over the GCV TCP command port
 (see :mod:`garmin_sidescan.commands`).  Rendering is left to downstream tools
 (``rqt_sonar_waterfall``); a ``debug_raw`` parameter can publish the raw UDP
 payloads on ``~/debug/raw`` for offline re-decode.
@@ -28,6 +31,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from rosidl_runtime_py.utilities import get_message
+from sensor_msgs.msg import Range
 from std_msgs.msg import Bool, String, UInt8MultiArray
 from std_srvs.srv import SetBool
 
@@ -40,12 +44,13 @@ from .commands import (
     TRANSMIT_ON,
 )
 from .decode import (
-    CHANNEL_OFFSET, dark_layer, EB07, echo_layer, generation_from_layers,
-    is_water_column, MIN_DATA_LEN, PingAssembler, status_transmitting)
+    CHANNEL_OFFSET, dark_layer, derive_sample_rate, EB07, echo_layer,
+    generation_from_layers, is_water_column, MIN_DATA_LEN, PingAssembler,
+    status_transmitting)
 
 # Auxiliary GCV multicast streams the driver can listen to. The imagery group
 # is a parameter (mcast_group/port); these two are fixed by the GCV protocol.
-STATUS_GROUP, STATUS_PORT = '239.254.2.2', 50050    # 8e03 status (tx flag + depth)
+STATUS_GROUP, STATUS_PORT = '239.254.2.2', 50050    # 8e03 status (tx flag)
 CONFIG_GROUP, CONFIG_PORT = '239.254.2.11', 51000   # chartplotter CDP config (debug-capture only)
 GEN_VOTE_MIN = 5                # packets to vote before latching the generation
 
@@ -72,6 +77,29 @@ SIDES = ('port', 'stbd', 'down')
 # URDF/TF tree orients it (side + downward tilt). Mounting -- including a
 # non-traditional/backwards install -- lives entirely in TF, never here.
 FRAME_SUFFIX = {'port': 'port', 'stbd': 'starboard', 'down': 'down'}
+
+
+def build_nadir_range(depth_m, frame_id, stamp, field_of_view, max_range):
+    """
+    Build a ``sensor_msgs/Range`` for a nadir bottom-range reading.
+
+    Per ``sensor_msgs/Range`` the range is measured along the **+X axis** of
+    ``frame_id``, so ``frame_id`` must be a dedicated nadir frame whose +X points
+    down -- NOT the water-column ``_down`` frame, which is Z-down (the marine
+    convention the down-look ``RawSonarImage`` uses; see ``docs/gcv_protocol.md``).
+    ``min_range`` is 0 so a genuinely shallow reading is not flagged invalid;
+    ``max_range`` bounds it at the configured swath maximum.  ``stamp`` is the
+    ping receive time (the imagery stream carries no transmit clock).
+    """
+    msg = Range()
+    msg.header.stamp = stamp
+    msg.header.frame_id = frame_id
+    msg.radiation_type = Range.ULTRASOUND
+    msg.field_of_view = float(field_of_view)
+    msg.min_range = 0.0
+    msg.max_range = float(max_range)
+    msg.range = float(depth_m)
+    return msg
 
 
 def transmit_state_after(commanded_on, send_ok, prior):
@@ -151,6 +179,14 @@ class GarminSidescanNode(Node):
         self.declare_parameter('freq_down_hz', 0.0)
         self.declare_parameter('sample_rate_hz', 0.0)
 
+        # Nadir bottom range (sensor_msgs/Range from the per-ping sub-header
+        # v1 varint, M3-validated). The Range beam axis is +X, so this needs
+        # its own frame whose +X points down -- distinct from the Z-down
+        # water-column _down frame. Empty -> derive '<frame_id>_nadir'; the
+        # platform URDF supplies the TF.
+        self.declare_parameter('nadir_frame_id', '')
+        self.declare_parameter('nadir_beam_width_rad', 0.0)   # Range.field_of_view
+
         # device generation. 'auto' detects from the render-layer structure
         # (GCV-10 = 3 layers, GCV-20 <= 2; see decode.generation_from_layers),
         # which is range-independent and picks the right per-packet echo
@@ -208,6 +244,8 @@ class GarminSidescanNode(Node):
             'down': float(self._p('freq_down_hz')),
         }
         self._sample_rate = float(self._p('sample_rate_hz'))
+        self._nadir_frame_id = self._p('nadir_frame_id') or f'{self._frame_id}_nadir'
+        self._nadir_fov = float(self._p('nadir_beam_width_rad'))
         self._chan_beamtype = {}      # ch -> 'sidescan'|'down' from pl[8]
         self._device = str(self._p('device')).lower()
         if self._device not in ('auto', 'gcv20', 'gcv10'):
@@ -274,9 +312,14 @@ class GarminSidescanNode(Node):
             'stbd': self.create_publisher(RawSonarImage, '~/sonar_image_starboard', img_qos),
             'down': self.create_publisher(RawSonarImage, '~/sonar_image_down', img_qos),
         }
+        # Nadir bottom range decoded from the down-look sub-header (per-ping
+        # v1 varint, M3-validated to ~1%), as a downward sensor_msgs/Range
+        # (see build_nadir_range / the _nadir frame). Per-ping sensor data, so
+        # the imagery QoS, not latched.
+        self._pub_depth = self.create_publisher(Range, '~/nadir_depth', img_qos)
         # Raw-payload debug capture (only published when debug_raw is true) --
         # one topic per GCV multicast stream so a single bag is fully
-        # re-decodable offline (imagery + status/depth + chartplotter config).
+        # re-decodable offline (imagery + status + chartplotter config).
         u8 = UInt8MultiArray
         self._pub_raw = self.create_publisher(u8, '~/debug/raw', img_qos)
         self._pub_raw_status = self.create_publisher(u8, '~/debug/raw_status', img_qos)
@@ -681,11 +724,11 @@ class GarminSidescanNode(Node):
                     f'device={self._device} but packet geometry looks like '
                     f'{detected}; imagery decode is likely wrong')
             now = self.get_clock().now()
-            for ch, samples, stamp in self._assembler.feed(payload, now):
-                self._emit_ping(ch, samples, stamp)
+            for line in self._assembler.feed(payload, now):
+                self._emit_ping(line)
         if self._assembler is not None:
-            for ch, samples, stamp in self._assembler.flush():
-                self._emit_ping(ch, samples, stamp)
+            for line in self._assembler.flush():
+                self._emit_ping(line)
         if sock is not None:
             sock.close()
 
@@ -754,15 +797,23 @@ class GarminSidescanNode(Node):
                 f'stream reports {observed} (render-layer byte); check the '
                 f'port/stbd/down channel map')
 
-    def _emit_ping(self, ch, samples, stamp):
-        side = self._chan_side.get(ch)
-        if side is None or not samples:
+    def _emit_ping(self, line):
+        side = self._chan_side.get(line.channel)
+        if side is None or not line.samples:
             return
         self._ping_count[side] += 1
         self._last_ping_t = time.monotonic()
-        self._pub_sonar[side].publish(self._make_sonar_msg(side, samples, stamp))
+        self._pub_sonar[side].publish(
+            self._make_sonar_msg(side, line.samples, line.stamp, line.subheader))
+        # Nadir bottom range: the per-ping sub-header v1 varint. It is shared
+        # across channels (the boat's depth), but published once per ping from
+        # the down-look -- the beam that actually measures it.
+        if side == 'down' and line.subheader and line.subheader.bottom_range_m > 0.0:
+            self._pub_depth.publish(build_nadir_range(
+                line.subheader.bottom_range_m, self._nadir_frame_id,
+                line.stamp.to_msg(), self._nadir_fov, self._range_max))
 
-    def _make_sonar_msg(self, side, samples, stamp):
+    def _make_sonar_msg(self, side, samples, stamp, sub=None):
         msg = RawSonarImage()
         msg.header.stamp = stamp.to_msg()
         # Per-channel frame so TF orients each transducer (see FRAME_SUFFIX).
@@ -770,17 +821,15 @@ class GarminSidescanNode(Node):
         msg.ping_info.frequency = self._freq[side]
         sv = self._current_sound_speed()
         msg.ping_info.sound_speed = sv
-        # Derive sample_rate so a consumer recovers range_max = sv*bins/(2*rate)
-        # = the commanded range. The GCV carries no rate/range in the payload,
-        # but the driver knows the range it commanded (mirrored in _controls).
-        # Only when we actually commanded a range (>0); else leave the manual
-        # override (default 0 = "unavailable", per RawSonarImage convention).
-        range_m = float(self._controls.get('range') or 0.0)
+        # Derive sample_rate so a consumer recovers range = sv*bins/(2*rate).
+        # The range source is the ping's OWN sub-header v2 (per channel, tracks
+        # hardware auto-range), falling back to the commanded-range mirror and
+        # then the sample_rate_hz parameter -- see decode.derive_sample_rate.
         bins = len(samples) // self._bytes_per_sample
-        if range_m > 0.0 and sv > 0.0 and bins > 0:
-            msg.sample_rate = float(sv) * bins / (2.0 * range_m)
-        else:
-            msg.sample_rate = self._sample_rate
+        msg.sample_rate = derive_sample_rate(
+            sub, bins, sv,
+            commanded_range_m=float(self._controls.get('range') or 0.0),
+            fallback_rate=self._sample_rate)
         msg.samples_per_beam = bins
         msg.sample0 = 0
         # rx_angles/tx_angles are the *steering* angle applied to the beam

--- a/garmin_sidescan/package.xml
+++ b/garmin_sidescan/package.xml
@@ -15,6 +15,7 @@
   <depend>marine_interfaces</depend>
   <depend>marine_radar_control_msgs</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <exec_depend>rcl_interfaces</exec_depend>

--- a/garmin_sidescan/test/test_decode.py
+++ b/garmin_sidescan/test/test_decode.py
@@ -10,10 +10,11 @@ import os
 import struct
 
 from garmin_sidescan.decode import (
-    dark_layer, decode_leb128, echo_layer, FH, GEN_BY_TAG, GEN_TAG_OFFSET,
-    generation_from_layers, is_water_column, parse_downlook_subheader,
-    parse_subheader, PingAssembler, SH, status_subtype, status_transmitting,
-    strip_first_layer_trailer, strip_leading_ping_header, subheader_bottom_range_m,
+    dark_layer, decode_leb128, derive_sample_rate, echo_layer, FH, GEN_BY_TAG,
+    GEN_TAG_OFFSET, generation_from_layers, is_water_column,
+    parse_downlook_subheader, parse_subheader, PingAssembler, SH,
+    status_subtype, status_transmitting, strip_first_layer_trailer,
+    strip_leading_ping_header, Subheader, subheader_bottom_range_m,
     TRAILER_MAGIC)
 
 FIXTURE = os.path.join(os.path.dirname(__file__), 'fixtures', 'gcv_real_pings.bin')
@@ -57,15 +58,20 @@ def test_real_capture_decodes_to_two_channel_scan_lines():
         pings.extend(assembler.feed(pl))
     pings.extend(assembler.flush())
 
-    channels = {ch for ch, _samples, _stamp in pings}
+    channels = {p.channel for p in pings}
     # GCV-10 survey data streams two side-scan channels (port=3, stbd=1)
     assert channels == {1, 3}
 
     # the two complete runs (7 packets each) form ~2048-bin scan lines
-    full = [len(s) for _ch, s, _t in pings if len(s) > 1000]
+    full = [len(p.samples) for p in pings if len(p.samples) > 1000]
     assert len(full) >= 2
     for width in full:
         assert 2000 <= width <= 2100
+
+    # The GCV-10 sub-header does not match the GCV-20 varint layout, so the
+    # assembler attaches no sub-header -- the driver's fallback chain (the
+    # commanded-range mirror) is load-bearing for this generation.
+    assert all(p.subheader is None for p in pings)
 
 
 def test_assembler_stamps_run_with_first_packet_time():
@@ -79,10 +85,11 @@ def test_assembler_stamps_run_with_first_packet_time():
     assert out == []                       # same channel, still accumulating
     out = assembler.feed(bytes([0xd8, 0x07]))   # marker flushes the run
     assert len(out) == 1
-    ch, samples, stamp = out[0]
-    assert ch == 5
-    assert stamp == 100.0                  # first packet's time, not the second
-    assert samples == bytes([10, 20, 30]) * 2
+    line = out[0]
+    assert line.channel == 5
+    assert line.stamp == 100.0             # first packet's time, not the second
+    assert line.samples == bytes([10, 20, 30]) * 2
+    assert line.subheader is None          # synthetic packet: no parseable sub
 
 
 # ----- GCV-20 echo extraction (echo_layer) -------------------------------
@@ -244,6 +251,57 @@ def test_parse_subheader_side_scan_has_own_display_range():
     assert parse_downlook_subheader(port) is None
 
 
+# ----- per-run sub-header attachment + scale derivation (issue #35) --------
+
+def test_assembler_attaches_run_subheader_on_gcv20_capture():
+    # Every scan line assembled from the real GCV-20 capture must carry its
+    # own run's sub-header: matching channel, plausible v1/v2 ranges. This is
+    # what the driver scales sample_rate (v2) and the nadir depth (v1) from.
+    assembler = PingAssembler(echo_layer)
+    pings = []
+    for pl in _load_records(GCV20_FIXTURE):
+        pings.extend(assembler.feed(pl))
+    pings.extend(assembler.flush())
+    assert pings
+    for p in pings:
+        assert p.subheader is not None
+        assert p.subheader.channel == p.channel
+        assert p.subheader.bottom_range_m > 0
+        assert p.subheader.display_range_m > 0
+
+
+def _sub(v2, v1=10.0):
+    return Subheader(channel=2, layer=0x0d, bracket=0x12,
+                     bottom_range_m=v1, display_range_m=v2, near_field_m=0.1)
+
+
+def test_derive_sample_rate_uses_own_channel_v2():
+    # A consumer recovers range = sv*bins/(2*rate); each channel's own v2 must
+    # round-trip, so the down-look (water column) and side-scan (slant swath)
+    # get DIFFERENT rates even with identical bins -- the asymmetry that a
+    # single commanded range cannot express.
+    sv, bins = 1500.0, 2048
+    down = derive_sample_rate(_sub(21.0), bins, sv, commanded_range_m=50.0)
+    side = derive_sample_rate(_sub(50.4), bins, sv, commanded_range_m=50.0)
+    assert abs(sv * bins / (2.0 * down) - 21.0) < 1e-9
+    assert abs(sv * bins / (2.0 * side) - 50.4) < 1e-9
+    assert down != side
+
+
+def test_derive_sample_rate_fallback_chain():
+    sv, bins = 1500.0, 2048
+    # no sub-header (e.g. GCV-10) -> the commanded range
+    rate = derive_sample_rate(None, bins, sv, commanded_range_m=50.0)
+    assert abs(sv * bins / (2.0 * rate) - 50.0) < 1e-9
+    # no sub-header, nothing commanded -> the configured fallback rate
+    assert derive_sample_rate(None, bins, sv, 0.0, fallback_rate=7.5) == 7.5
+    # ...which defaults to 0.0 = "unavailable" (RawSonarImage convention)
+    assert derive_sample_rate(None, bins, sv, 0.0) == 0.0
+    # a range without a sound speed (or bins) cannot derive a rate
+    assert derive_sample_rate(_sub(21.0), bins, 0.0, 50.0, fallback_rate=7.5) == 7.5
+    assert derive_sample_rate(_sub(21.0), 0, sv, 50.0, fallback_rate=7.5) == 7.5
+
+
 # ----- GCV-20 trailer / leading-header stripping (issue #26) --------------
 
 def test_strip_first_layer_trailer_removes_delimited_trailer():
@@ -300,9 +358,9 @@ def test_gcv20_real_capture_strips_trailer_and_leading_band():
     pings.extend(assembler.flush())
 
     # fixture spans down-look (ch2) + both side-scan (ch0/ch1) runs
-    assert {ch for ch, _s, _t in pings} >= {0, 1, 2}
+    assert {p.channel for p in pings} >= {0, 1, 2}
     assert len(pings) >= 3
-    for ch, samples, _t in pings:
+    for ch, samples, _t, _sub in pings:
         # no per-packet trailer bytes survive into the scan line
         assert TRAILER_MAGIC not in samples, f'trailer leaked into ch{ch}'
         # no long constant leading run (the bright near-range band)
@@ -324,6 +382,5 @@ def test_assembler_uses_supplied_extractor():
     assert assembler.feed(pkt) == []                # accumulating
     out = assembler.feed(bytes([0xd8, 0x07]))       # marker flushes
     assert len(out) == 1
-    ch, samples, _stamp = out[0]
-    assert ch == 7
-    assert samples == bytes([10, 1, 20, 2, 30, 3, 40, 4])
+    assert out[0].channel == 7
+    assert out[0].samples == bytes([10, 1, 20, 2, 30, 3, 40, 4])

--- a/garmin_sidescan/test/test_decode.py
+++ b/garmin_sidescan/test/test_decode.py
@@ -384,3 +384,24 @@ def test_assembler_uses_supplied_extractor():
     assert len(out) == 1
     assert out[0].channel == 7
     assert out[0].samples == bytes([10, 1, 20, 2, 30, 3, 40, 4])
+
+
+def test_d807_marker_tags_an_adjacent_run_channel():
+    # Markers bracket channel runs in close/open pairs; each tags an adjacent
+    # run's channel in its trailing `19 <channel>` bytes (gcv_protocol.md
+    # section 3.C -- 94% verified with bracket+v1 on the 2026-06-11 capture).
+    # Pin the structure on the real GCV-20 fixture window.
+    records = _load_records(GCV20_FIXTURE)
+    run_ch = [pl[12] if pl[:2] == b'\xeb\x07' and len(pl) > 32 else None
+              for pl in records]
+    checked = 0
+    for i, pl in enumerate(records):
+        if pl[:2] != b'\xd8\x07' or len(pl) < 10:
+            continue
+        assert pl[8] == 0x02                  # constant record opener
+        assert pl[-2] == 0x19                 # channel tag marker
+        prev_ch = next((c for c in reversed(run_ch[:i]) if c is not None), None)
+        next_ch = next((c for c in run_ch[i + 1:] if c is not None), None)
+        assert pl[-1] in {prev_ch, next_ch} - {None}   # tags an adjacent run
+        checked += 1
+    assert checked >= 2                       # fixture spans multiple runs

--- a/garmin_sidescan/test/test_decode.py
+++ b/garmin_sidescan/test/test_decode.py
@@ -10,12 +10,11 @@ import os
 import struct
 
 from garmin_sidescan.decode import (
-    dark_layer, decode_leb128, derive_sample_rate, echo_layer, FH, GEN_BY_TAG,
-    GEN_TAG_OFFSET, generation_from_layers, is_water_column,
-    parse_downlook_subheader, parse_subheader, PingAssembler, SH,
-    status_subtype, status_transmitting, strip_first_layer_trailer,
-    strip_leading_ping_header, Subheader, subheader_bottom_range_m,
-    TRAILER_MAGIC)
+    dark_layer, decode_leb128, derive_sample_rate, echo_layer, FH,
+    generation_from_layers, is_water_column, parse_downlook_subheader,
+    parse_subheader, PingAssembler, SH, status_subtype, status_transmitting,
+    strip_first_layer_trailer, strip_leading_ping_header, Subheader,
+    subheader_bottom_range_m, TRAILER_MAGIC)
 
 FIXTURE = os.path.join(os.path.dirname(__file__), 'fixtures', 'gcv_real_pings.bin')
 # Real GCV-20 capture (2026-06-09 wet test, issue #26): a contiguous window of
@@ -68,10 +67,15 @@ def test_real_capture_decodes_to_two_channel_scan_lines():
     for width in full:
         assert 2000 <= width <= 2100
 
-    # The GCV-10 sub-header does not match the GCV-20 varint layout, so the
-    # assembler attaches no sub-header -- the driver's fallback chain (the
-    # commanded-range mirror) is load-bearing for this generation.
-    assert all(p.subheader is None for p in pings)
+    # The GCV-10 sub-header is the same tagged-record grammar (its v3 is a
+    # 1-byte varint, tag 0x29) -- Dan's survey ran at a commanded 20 m range,
+    # so every run's own v2 must read exactly 20.00 m, with a real bottom
+    # range in v1 and the channel matching the run.
+    for p in pings:
+        assert p.subheader is not None
+        assert p.subheader.channel == p.channel
+        assert abs(p.subheader.display_range_m - 20.0) < 0.01
+        assert 7.0 < p.subheader.bottom_range_m < 11.0
 
 
 def test_assembler_stamps_run_with_first_packet_time():
@@ -130,7 +134,8 @@ def test_echo_layer_empty_without_first_header():
 def test_generation_from_layers_on_real_fixtures():
     # Range-INDEPENDENT generation: GCV-10 packets carry >=2 SH/SHS later-layer
     # headers (3 layers); GCV-20 carry <=1 (<=2 layers). Validated on the real
-    # capture fixtures (the byte-13 'gen tag' is actually the range bracket).
+    # capture fixtures (byte 13 is field2's tag -- v1 varint length -- which
+    # once masqueraded as a 'gen tag' and then as a 'range bracket').
     g10 = [generation_from_layers(p) for p in load_fixture() if p[:2] == b'\xeb\x07']
     g20 = [generation_from_layers(p) for p in _load_records(GCV20_FIXTURE)
            if p[:2] == b'\xeb\x07']
@@ -145,17 +150,6 @@ def test_generation_from_layers_synthetic():
     assert generation_from_layers(pre + FH + SH + bytes(8) + SH + bytes(8)) == 'gcv10'  # 2 SH
     assert generation_from_layers(bytes([0xeb, 0x07, 0, 0]) + bytes(40)) is None    # no FH
     assert generation_from_layers(bytes([0xd8, 0x07]) + bytes(40)) is None          # not eb07
-
-
-def test_generation_tag_byte_discriminates():
-    # sub-header value-width tag at offset 13: 0x11=GCV-10, 0x12=GCV-20
-    g10 = _gcv20_packet(0, bytes(8))
-    g20 = _gcv20_packet(0, bytes(8))
-    g10 = g10[:GEN_TAG_OFFSET] + bytes([0x11]) + g10[GEN_TAG_OFFSET + 1:]
-    g20 = g20[:GEN_TAG_OFFSET] + bytes([0x12]) + g20[GEN_TAG_OFFSET + 1:]
-    assert GEN_BY_TAG.get(g10[GEN_TAG_OFFSET]) == 'gcv10'
-    assert GEN_BY_TAG.get(g20[GEN_TAG_OFFSET]) == 'gcv20'
-    assert GEN_BY_TAG.get(0x99) is None          # unknown tag -> undecided
 
 
 def _img_with_layer(layer):
@@ -230,7 +224,7 @@ def test_parse_downlook_subheader():
     pkt = bytes.fromhex('eb07000000000000') + bytes.fromhex(
         '0d0103090212907f190023acbd012ab20131023fda04d804') + bytes(8)  # + samples
     sub = parse_downlook_subheader(pkt)
-    assert sub.bracket == 0x12
+    assert sub.v1_tag == 0x12   # field2, 2-byte v1
     assert abs(sub.bottom_range_m - 8.136) < 0.01     # v1
     assert abs(sub.display_range_m - 12.118) < 0.01   # v2
     assert abs(sub.near_field_m - 0.089) < 0.01       # v3
@@ -271,7 +265,7 @@ def test_assembler_attaches_run_subheader_on_gcv20_capture():
 
 
 def _sub(v2, v1=10.0):
-    return Subheader(channel=2, layer=0x0d, bracket=0x12,
+    return Subheader(channel=2, layer=0x0d, v1_tag=0x12,
                      bottom_range_m=v1, display_range_m=v2, near_field_m=0.1)
 
 
@@ -290,7 +284,7 @@ def test_derive_sample_rate_uses_own_channel_v2():
 
 def test_derive_sample_rate_fallback_chain():
     sv, bins = 1500.0, 2048
-    # no sub-header (e.g. GCV-10) -> the commanded range
+    # no sub-header (garbled packet) -> the commanded range
     rate = derive_sample_rate(None, bins, sv, commanded_range_m=50.0)
     assert abs(sv * bins / (2.0 * rate) - 50.0) < 1e-9
     # no sub-header, nothing commanded -> the configured fallback rate
@@ -384,6 +378,30 @@ def test_assembler_uses_supplied_extractor():
     assert len(out) == 1
     assert out[0].channel == 7
     assert out[0].samples == bytes([10, 1, 20, 2, 30, 3, 40, 4])
+
+
+def test_subheader_grammar_tags_encode_varint_length_on_both_fixtures():
+    # The sub-header is a tagged record: tag = (field# << 3) | L where L is
+    # the value's LEB128 byte length -- verified with zero exceptions on 697k+
+    # frames across five captures and both generations (gcv_protocol.md
+    # section 3). Pin the invariant on every fixture packet.
+    from garmin_sidescan.decode import V1_TAG_OFFSET
+
+    checked = 0
+    for fixture in (FIXTURE, GCV20_FIXTURE):
+        for pl in _load_records(fixture):
+            if pl[:2] != b'\xeb\x07' or len(pl) <= 32:
+                continue
+            i = V1_TAG_OFFSET
+            for want_field in (2, 3, 4, 5):
+                tag = pl[i]
+                assert tag >> 3 == want_field
+                value, end = decode_leb128(pl, i + 1)
+                assert value is not None
+                assert end - (i + 1) == tag & 0x07   # low bits = varint length
+                i = end
+            checked += 1
+    assert checked >= 60                  # both fixtures contribute
 
 
 def test_d807_marker_tags_an_adjacent_run_channel():

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -10,6 +10,7 @@ import types
 from diagnostic_msgs.msg import DiagnosticStatus
 from garmin_sidescan.decode import FH, SH
 from garmin_sidescan.node import (
+    build_nadir_range,
     GarminSidescanNode,
     GEN_VOTE_MIN,
     imagery_diag_level,
@@ -303,3 +304,20 @@ def test_status_heartbeat_republishes_control_set():
     node._pub_status = types.SimpleNamespace(publish=lambda msg: None)
     GarminSidescanNode._publish_status(node)
     assert node.publishes == 1
+
+
+# ----- nadir bottom range (sub-header v1 -> sensor_msgs/Range, issue #16) --
+
+def test_build_nadir_range_maps_bottom_range_to_downward_range():
+    from builtin_interfaces.msg import Time
+    from sensor_msgs.msg import Range
+
+    msg = build_nadir_range(14.58, 'gs_nadir', Time(sec=5, nanosec=0),
+                            field_of_view=0.2, max_range=60.0)
+    assert msg.header.frame_id == 'gs_nadir'        # dedicated +X-down frame
+    assert msg.header.stamp.sec == 5                # ping receive-time stamp
+    assert msg.radiation_type == Range.ULTRASOUND
+    assert abs(msg.range - 14.58) < 1e-4            # v1 bottom range -> range
+    assert msg.min_range == 0.0                     # shallow not flagged invalid
+    assert abs(msg.max_range - 60.0) < 1e-4
+    assert abs(msg.field_of_view - 0.2) < 1e-4

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -348,3 +348,36 @@ def test_make_sonar_msg_down_never_takes_commanded_range_fallback():
     assert abs(1500.0 * 2048 / (2.0 * side_msg.sample_rate) - 50.0) < 1e-6
     # down: no commanded fallback -> 0.0 = unavailable
     assert down_msg.sample_rate == 0.0
+
+
+def test_emit_ping_skips_implausible_nadir_values():
+    from garmin_sidescan.decode import ScanLine, Subheader
+
+    published = []
+
+    def sub(v1, v2):
+        return Subheader(channel=2, layer=0x0d, v1_tag=0x12,
+                         bottom_range_m=v1, display_range_m=v2,
+                         near_field_m=0.1)
+
+    def fake():
+        return types.SimpleNamespace(
+            _chan_side={2: 'down'},
+            _ping_count={'down': 0},
+            _pub_sonar={'down': types.SimpleNamespace(publish=lambda m: None)},
+            _pub_depth=types.SimpleNamespace(publish=published.append),
+            _make_sonar_msg=lambda *a, **k: None,
+            _nadir_frame_id='gs_nadir', _nadir_fov=0.0,
+            _emit_ping=GarminSidescanNode._emit_ping)
+        # _make_sonar_msg stubbed: this test pins only the nadir gate
+
+    stamp = types.SimpleNamespace(to_msg=lambda: None)
+    node = fake()
+    # plausible: 0 < v1 <= v2 -> published with max_range = v2
+    GarminSidescanNode._emit_ping(node, ScanLine(2, b'xx', stamp, sub(7.5, 21.0)))
+    assert len(published) == 1 and abs(published[0].max_range - 21.0) < 1e-6
+    # corrupt: v1 beyond the observable window -> no spec-invalid Range
+    GarminSidescanNode._emit_ping(node, ScanLine(2, b'xx', stamp, sub(30.0, 21.0)))
+    # degenerate: non-positive v1 -> skipped
+    GarminSidescanNode._emit_ping(node, ScanLine(2, b'xx', stamp, sub(0.0, 21.0)))
+    assert len(published) == 1

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -321,3 +321,30 @@ def test_build_nadir_range_maps_bottom_range_to_downward_range():
     assert msg.min_range == 0.0                     # shallow not flagged invalid
     assert abs(msg.max_range - 60.0) < 1e-4
     assert abs(msg.field_of_view - 0.2) < 1e-4
+
+
+def test_make_sonar_msg_down_never_takes_commanded_range_fallback():
+    # The commanded range is the side-scan swath; the down-look's true range
+    # is its auto-ranged water-column extent. With no parseable sub-header
+    # (e.g. GCV-10) the side channels may fall back to the commanded range,
+    # but the down channel must publish "unavailable" rather than a
+    # confidently-wrong ~2x scale.
+    from builtin_interfaces.msg import Time
+
+    def fake(side):
+        return types.SimpleNamespace(
+            _frame_id='gs', _freq={side: 0.0},
+            _current_sound_speed=lambda: 1500.0,
+            _controls={'range': '50.0'},
+            _bytes_per_sample=2, _sample_rate=0.0, _sonar_dtype=0,
+            _make_sonar_msg=GarminSidescanNode._make_sonar_msg)
+    samples = bytes(4096)                       # 2048 uint16 bins
+    stamp = types.SimpleNamespace(to_msg=lambda: Time())
+    side_msg = GarminSidescanNode._make_sonar_msg(
+        fake('port'), 'port', samples, stamp, sub=None)
+    down_msg = GarminSidescanNode._make_sonar_msg(
+        fake('down'), 'down', samples, stamp, sub=None)
+    # side: commanded fallback engages -> range round-trips to 50.0
+    assert abs(1500.0 * 2048 / (2.0 * side_msg.sample_rate) - 50.0) < 1e-6
+    # down: no commanded fallback -> 0.0 = unavailable
+    assert down_msg.sample_rate == 0.0

--- a/garmin_sidescan/tools/README.md
+++ b/garmin_sidescan/tools/README.md
@@ -3,9 +3,12 @@
 ## `sidescan_waterfall.py` — offline waterfall image (QA)
 
 Renders a two-panel waterfall (down-look depth-corrected on top, side-scan
-port|starboard below, shared time axis) from a bag, using the **same decoder as
-the driver** (`garmin_sidescan.decode`). Self-contained — needs only the sidescan
-`debug/raw` topic (record with `debug_raw:=true`); no external nav/sonar. The
+port|starboard below, shared time axis) from a bag. Two sources (`--source`,
+default auto): `raw` decodes `debug/raw` with the **same decoder as the
+driver** (`garmin_sidescan.decode`); `messages` renders the published
+`sonar_image_*` topics (per-ping scale from `sample_rate`, bottom line from
+`nadir_depth` — needs a bag recorded by the #35+ driver). Self-contained
+either way; no external nav/sonar. The
 metres-per-sample scale is self-derived per channel from the device's per-ping
 **display-range varint** (sub-header `v2`); no hard-coded calibration. Sample
 values are shown raw on a single global brightness scale (no per-ping

--- a/garmin_sidescan/tools/README.md
+++ b/garmin_sidescan/tools/README.md
@@ -47,8 +47,9 @@ ros2 run garmin_sidescan garmin_sidescan --ros-args \
     -p iface_ip:=127.0.0.1 -p filter_src:=false -p require_sound_speed:=false
 # terminal 2 — the replay
 python3 tools/replay_debug_raw.py BAG --start 100 --end 300
-# terminal 3 — watch the output
-ros2 topic echo /garmin_sidescan/nadir_depth
+# terminal 3 — watch the output (sensor topics are best-effort; a
+# default-reliable echo silently shows nothing)
+ros2 topic echo --qos-reliability best_effort /garmin_sidescan/nadir_depth
 ```
 
 ---

--- a/garmin_sidescan/tools/README.md
+++ b/garmin_sidescan/tools/README.md
@@ -19,6 +19,38 @@ python3 tools/sidescan_waterfall.py BAG --start 100 --end 620 --out wf.png
 Needs a sourced workspace (for `garmin_sidescan` on the path) plus numpy +
 matplotlib.
 
+## `verify_range_scale.py` — interactive range-scale + nadir-depth check
+
+Plots, from a `debug/raw` bag on a shared time axis: each channel's per-ping
+sub-header **v2 display range** (the scale the driver publishes via
+`sample_rate`, issue #35) with byte-13 bracket transitions marked, the
+down-look **v1 bottom range** (published as `nadir_depth`, issue #16), and —
+for before/after comparison — the implied range actually recorded in the bag's
+`sonar_image_*` messages plus the `state` topic's commanded-range mirror.
+Interactive matplotlib window by default (zoom into the auto-range
+transitions); `--out FILE` renders a PNG headless.
+
+```bash
+python3 tools/verify_range_scale.py BAG [--start S --end S] [--out check.png]
+```
+
+## `replay_debug_raw.py` — replay a bag onto the imagery multicast
+
+Hardware-free end-to-end driver testing: re-sends a bag's `debug/raw`
+datagrams to the GCV multicast group, paced by bag timestamps, so the **actual
+driver node** (socket layer up) processes a real capture live. Defaults to
+loopback (`--iface-ip 127.0.0.1`, TTL 0) so nothing leaves the host.
+
+```bash
+# terminal 1 — the driver under test
+ros2 run garmin_sidescan garmin_sidescan --ros-args \
+    -p iface_ip:=127.0.0.1 -p filter_src:=false -p require_sound_speed:=false
+# terminal 2 — the replay
+python3 tools/replay_debug_raw.py BAG --start 100 --end 300
+# terminal 3 — watch the output
+ros2 topic echo /garmin_sidescan/nadir_depth
+```
+
 ---
 
 # Marine Network proxy

--- a/garmin_sidescan/tools/replay_debug_raw.py
+++ b/garmin_sidescan/tools/replay_debug_raw.py
@@ -116,6 +116,8 @@ def main(argv=None):
     ap.add_argument('--end', type=float, default=1e9, help='window end (s)')
     args = ap.parse_args(argv)
 
+    if args.rate <= 0:
+        sys.exit('error: --rate must be > 0 (it divides the pacing deadline)')
     raw_topic = find_raw_topic(args.bag)
     if raw_topic is None:
         sys.exit('error: no */debug/raw topic in the bag — record with debug_raw:=true')

--- a/garmin_sidescan/tools/replay_debug_raw.py
+++ b/garmin_sidescan/tools/replay_debug_raw.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Replay a recorded ``debug/raw`` stream onto the GCV imagery multicast.
+
+Hardware-free end-to-end driver testing: feeds the **actual driver node** the
+same UDP datagrams a live GCV produced, paced by the bag's receive timestamps,
+so every layer from the multicast socket up (generation vote, assembler,
+sub-header scaling, ``nadir_depth``) runs exactly as on the boat.  Point a
+``ros2 topic echo`` / rqt waterfall at the driver's output while replaying.
+
+Run the driver against the replay on the same host::
+
+    ros2 run garmin_sidescan garmin_sidescan --ros-args \
+        -p iface_ip:=127.0.0.1 -p filter_src:=false -p require_sound_speed:=false
+
+    python3 replay_debug_raw.py BAG [--rate 1.0] [--start S] [--end S]
+
+``filter_src:=false`` is required (replayed packets carry the replayer's
+source address, not the GCV's). ``iface_ip:=127.0.0.1`` on both ends keeps
+the multicast on loopback — nothing leaks onto a live boat network, and the
+replay works with no NIC configured. The driver stays passive: it never
+transmits unless commanded, and there is no GCV TCP endpoint here anyway.
+
+Requires a bag recorded with ``debug_raw:=true``. Run in a sourced workspace.
+"""
+import argparse
+import socket
+import sys
+import time
+
+from rclpy.serialization import deserialize_message
+import rosbag2_py
+from std_msgs.msg import UInt8MultiArray
+
+
+def _reader(bag):
+    r = rosbag2_py.SequentialReader()
+    r.open(rosbag2_py.StorageOptions(uri=bag, storage_id='mcap'),
+           rosbag2_py.ConverterOptions(input_serialization_format='cdr',
+                                       output_serialization_format='cdr'))
+    return r
+
+
+def find_raw_topic(bag):
+    """Return the first topic ending in ``debug/raw``, or None."""
+    for t in _reader(bag).get_all_topics_and_types():
+        if t.name.endswith('debug/raw'):
+            return t.name
+    return None
+
+
+def open_sender(iface_ip, ttl):
+    """Return a UDP socket configured to send multicast on ``iface_ip``."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
+    # Loop back to local receivers (the driver under test on this host).
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
+    if iface_ip:
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
+                        socket.inet_aton(iface_ip))
+    return sock
+
+
+def replay(bag, raw_topic, dest, iface_ip, ttl, rate, start, end):
+    """Send the bag's raw payloads to ``dest``, paced by bag timestamps."""
+    sock = open_sender(iface_ip, ttl)
+    r = _reader(bag)
+    t0 = None            # first bag timestamp (ns)
+    wall0 = None         # wall clock at the first sent packet
+    sent = 0
+    try:
+        while r.has_next():
+            topic, data, ts = r.read_next()
+            if topic != raw_topic:
+                continue
+            if t0 is None:
+                t0 = ts
+            rel = (ts - t0) / 1e9
+            if rel < start:
+                continue
+            if rel > end:
+                break
+            if wall0 is None:
+                wall0 = time.monotonic() - rel / rate
+            lag = rel / rate - (time.monotonic() - wall0)
+            if lag > 0:
+                time.sleep(lag)
+            payload = bytes(deserialize_message(data, UInt8MultiArray).data)
+            sock.sendto(payload, dest)
+            sent += 1
+            if sent % 5000 == 0:
+                print(f'  t={rel:7.1f}s  {sent} datagrams', flush=True)
+    except KeyboardInterrupt:
+        print('\ninterrupted', file=sys.stderr)
+    finally:
+        sock.close()
+    print(f'replayed {sent} datagrams to {dest[0]}:{dest[1]}')
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[1])
+    ap.add_argument('bag', help='path to an mcap bag recorded with debug_raw:=true')
+    ap.add_argument('--group', default='239.254.2.1',
+                    help='destination multicast group (driver mcast_group)')
+    ap.add_argument('--port', type=int, default=50220,
+                    help='destination port (driver mcast_port)')
+    ap.add_argument('--iface-ip', default='127.0.0.1',
+                    help='interface to send multicast on (default loopback; '
+                         'match the driver iface_ip)')
+    ap.add_argument('--ttl', type=int, default=0,
+                    help='multicast TTL (default 0 = never leaves the host)')
+    ap.add_argument('--rate', type=float, default=1.0,
+                    help='playback speed multiplier')
+    ap.add_argument('--start', type=float, default=0.0,
+                    help='window start (s, relative to the first raw datagram)')
+    ap.add_argument('--end', type=float, default=1e9, help='window end (s)')
+    args = ap.parse_args(argv)
+
+    raw_topic = find_raw_topic(args.bag)
+    if raw_topic is None:
+        sys.exit('error: no */debug/raw topic in the bag — record with debug_raw:=true')
+    print(f'replaying {raw_topic}\n  -> {args.group}:{args.port} '
+          f'(iface {args.iface_ip or "default"}, ttl {args.ttl}, x{args.rate})')
+    replay(args.bag, raw_topic, (args.group, args.port), args.iface_ip,
+           args.ttl, args.rate, args.start, args.end)
+
+
+if __name__ == '__main__':
+    main()

--- a/garmin_sidescan/tools/sidescan_waterfall.py
+++ b/garmin_sidescan/tools/sidescan_waterfall.py
@@ -35,8 +35,7 @@ Requires a bag recorded with ``debug_raw:=true``. Run in a sourced workspace
 import argparse
 import sys
 
-from garmin_sidescan.decode import (
-    D807, EB07, echo_layer, parse_subheader, PingAssembler)
+from garmin_sidescan.decode import D807, EB07, echo_layer, PingAssembler
 import numpy as np
 from rclpy.serialization import deserialize_message
 import rosbag2_py
@@ -65,13 +64,13 @@ def read_pings(bag, raw_topic, start, end):
     """
     Assemble pings in ``[start, end]``.
 
-    Returns ``{channel: [(t, sub, samples)]}`` where ``sub`` is the parsed
-    sub-header for that channel (None if it failed to parse).
+    Returns ``{channel: [(t, sub, samples)]}`` where ``sub`` is the run's own
+    parsed sub-header, attached by the assembler (None if no packet of the
+    run parsed) -- the same per-ping sub-header the driver scales from.
     """
     r = _reader(bag)
     t0 = None
     asm = PingAssembler(echo_layer)
-    subs = {}                         # channel -> latest parsed Subheader
     chans = {DOWN: [], PORT: [], STBD: []}
     while r.has_next():
         topic, data, ts = r.read_next()
@@ -84,19 +83,14 @@ def read_pings(bag, raw_topic, start, end):
             break
         b = bytes(deserialize_message(data, UInt8MultiArray).data)
         out = []
-        if b[:2] == EB07 and len(b) > 32:
-            s = parse_subheader(b)
-            if s is not None:
-                subs[s.channel] = s
+        if (b[:2] == EB07 and len(b) > 32) or b[:2] == D807:
             out = asm.feed(b, recv_time=rel)
-        elif b[:2] == D807:
-            out = asm.feed(b, recv_time=rel)
-        for ch, samp, st in out:
+        for ch, samp, st, sub in out:
             if start <= st <= end and ch in chans:
-                chans[ch].append((st, subs.get(ch), samp))
-    for ch, samp, st in asm.flush():           # emit the final accumulated run
+                chans[ch].append((st, sub, samp))
+    for ch, samp, st, sub in asm.flush():      # emit the final accumulated run
         if start <= st <= end and ch in chans:
-            chans[ch].append((st, subs.get(ch), samp))
+            chans[ch].append((st, sub, samp))
     return chans
 
 

--- a/garmin_sidescan/tools/sidescan_waterfall.py
+++ b/garmin_sidescan/tools/sidescan_waterfall.py
@@ -39,7 +39,8 @@ import argparse
 import collections
 import sys
 
-from garmin_sidescan.decode import D807, EB07, echo_layer, PingAssembler
+from garmin_sidescan.decode import (
+    D807, dark_layer, EB07, echo_layer, generation_from_layers, PingAssembler)
 import numpy as np
 from rclpy.serialization import deserialize_message
 import rosbag2_py
@@ -79,7 +80,8 @@ def read_pings(bag, raw_topic, start, end):
     """
     r = _reader(bag)
     t0 = None
-    asm = PingAssembler(echo_layer)
+    asm = None                    # built once the generation vote resolves
+    gen_votes = []
     chans = {DOWN: [], PORT: [], STBD: []}
     while r.has_next():
         topic, data, ts = r.read_next()
@@ -91,13 +93,23 @@ def read_pings(bag, raw_topic, start, end):
         if rel > end + 2:
             break
         b = bytes(deserialize_message(data, UInt8MultiArray).data)
+        if asm is None:
+            # Pick the echo extractor from the stream itself (GCV-10 dark
+            # layer vs GCV-20 first layer), voted like the driver.
+            g = generation_from_layers(b)
+            if g is not None:
+                gen_votes.append(g)
+            if len(gen_votes) < 5:
+                continue
+            gen = max(set(gen_votes), key=gen_votes.count)
+            asm = PingAssembler(dark_layer if gen == 'gcv10' else echo_layer)
         out = []
         if (b[:2] == EB07 and len(b) > 32) or b[:2] == D807:
             out = asm.feed(b, recv_time=rel)
         for ch, samp, st, sub in out:
             if start <= st <= end and ch in chans:
                 chans[ch].append((st, sub, samp))
-    for ch, samp, st, sub in asm.flush():      # emit the final accumulated run
+    for ch, samp, st, sub in (asm.flush() if asm else []):
         if start <= st <= end and ch in chans:
             chans[ch].append((st, sub, samp))
     return chans
@@ -286,8 +298,8 @@ def main(argv=None):
                     help='raw-value white point (default a global 99.5%% percentile; '
                          'use 65535 for full uint16 range)')
     ap.add_argument('--source', choices=('auto', 'raw', 'messages'), default='auto',
-                    help='input: raw = decode debug/raw with the driver own '
-                         'decoder; messages = render the published '
+                    help='input: raw = decode debug/raw with the same decoder '
+                         'as the driver; messages = render the published '
                          'sonar_image_* (scale from sample_rate, bottom line '
                          'from nadir_depth); auto prefers raw when present')
     args = ap.parse_args(argv)

--- a/garmin_sidescan/tools/sidescan_waterfall.py
+++ b/garmin_sidescan/tools/sidescan_waterfall.py
@@ -11,14 +11,17 @@ over a time window:
     metres via the sub-header v2 range; NO ground-range / slant correction);
   * shared time x-axis.
 
-It is **self-contained** — it depends only on the sidescan ``debug/raw`` topic,
-no external nav/sonar (no M3). The metres-per-sample scale comes straight from
-each channel's sub-header: ``bin_size = display_range / n_bins`` where the
-display range is that channel's per-ping ``v2`` varint (see
-``docs/gcv_protocol.md``). The down-look's v2 is the water-column depth range;
-the side-scan's v2 is its slant-range swath extent (~2x larger), so each channel
-is scaled by its OWN v2. No bottom detection, no hard-coded ladder. The down-look
-``v1`` (bottom range) is drawn on the water-column panel as a check.
+Two input sources (``--source``, default auto): the sidescan ``debug/raw``
+topic decoded with the driver's own decoder, or the driver's published
+``sonar_image_*`` messages (per-ping scale recovered from ``sample_rate``,
+issue #35; bottom line from ``~/nadir_depth``). Either way it is
+**self-contained** — no external nav/sonar (no M3). The metres-per-sample
+scale comes from each channel's own per-ping display range (sub-header ``v2``,
+see ``docs/gcv_protocol.md``): the down-look's is the water-column depth
+range, the side-scan's its slant-range swath extent (~2x larger), so each
+channel is scaled by its OWN range. No bottom detection, no hard-coded
+ladder. The down-look bottom range (``v1`` / ``nadir_depth``) is drawn on the
+water-column panel as a check.
 
 Sample values are shown **as decoded** (raw ``uint16``) on a single global
 linear brightness scale per panel — no per-ping/contrast manipulation, so the
@@ -27,12 +30,13 @@ transform is spatial: resampling sample-index onto a metric axis. ``vmax``
 defaults to a global high percentile (robust to the near-field spike); override
 with ``--vmax``/``--vmin`` for the full ``uint16`` range.
 
-Requires a bag recorded with ``debug_raw:=true``. Run in a sourced workspace
-(needs ``garmin_sidescan`` on the path) with numpy + matplotlib available:
+Run in a sourced workspace (needs ``garmin_sidescan`` on the path) with
+numpy + matplotlib available:
 
     python3 sidescan_waterfall.py BAG [--start S] [--end S] [--out out.png]
 """
 import argparse
+import collections
 import sys
 
 from garmin_sidescan.decode import D807, EB07, echo_layer, PingAssembler
@@ -42,6 +46,11 @@ import rosbag2_py
 from std_msgs.msg import UInt8MultiArray
 
 DOWN, PORT, STBD = 2, 0, 1        # GCV-20 channel map
+
+# Per-ping scale shim for the messages source: the renderer needs only these
+# two Subheader attributes, recovered from each RawSonarImage
+# (range = sound_speed * bins / (2 * sample_rate)) and from ~/nadir_depth.
+MsgScale = collections.namedtuple('MsgScale', 'display_range_m bottom_range_m')
 
 
 def _reader(bag):
@@ -91,6 +100,81 @@ def read_pings(bag, raw_topic, start, end):
     for ch, samp, st, sub in asm.flush():      # emit the final accumulated run
         if start <= st <= end and ch in chans:
             chans[ch].append((st, sub, samp))
+    return chans
+
+
+def read_pings_messages(bag, start, end):
+    """
+    Build the same ``{channel: [(t, sub, samples)]}`` from ``sonar_image_*``.
+
+    The decoded-message source (#35): per-ping scale recovered from
+    ``sample_rate`` (``range = sound_speed * bins / (2 * rate)``), the bottom
+    line from ``~/nadir_depth`` when recorded.  Bags recorded before the
+    driver published a scale (``sample_rate`` = 0) cannot be rendered from
+    messages -- use the ``debug/raw`` source for those.
+    """
+    from marine_acoustic_msgs.msg import RawSonarImage
+    from sensor_msgs.msg import Range
+
+    side_to_ch = {'port': PORT, 'starboard': STBD, 'down': DOWN}
+    img_topics = {}
+    nadir_topic = None
+    r = _reader(bag)
+    for t in r.get_all_topics_and_types():
+        for side, ch in side_to_ch.items():
+            if t.name.endswith(f'sonar_image_{side}'):
+                img_topics[t.name] = ch
+        if t.name.endswith('nadir_depth'):
+            nadir_topic = t.name
+    if not img_topics:
+        sys.exit('error: no sonar_image_* topics in the bag')
+
+    chans = {DOWN: [], PORT: [], STBD: []}
+    nadir = []                       # (t, bottom_range_m) from ~/nadir_depth
+    t0 = None
+    unscaled = 0
+    while r.has_next():
+        topic, data, ts = r.read_next()
+        if topic not in img_topics and topic != nadir_topic:
+            continue
+        if t0 is None:
+            t0 = ts
+        rel = (ts - t0) / 1e9
+        if rel > end:
+            break
+        if rel < start:
+            continue
+        if topic == nadir_topic:
+            m = deserialize_message(data, Range)
+            nadir.append((rel, m.range))
+            continue
+        m = deserialize_message(data, RawSonarImage)
+        sv, rate = m.ping_info.sound_speed, m.sample_rate
+        if rate > 0 and sv > 0 and m.samples_per_beam > 0:
+            rng = sv * m.samples_per_beam / (2.0 * rate)
+        else:
+            rng = None
+            unscaled += 1
+        samples = bytes(m.image.data)
+        if m.image.dtype == 0:           # DTYPE_UINT8 (GCV-10) -> uint16 LE
+            samples = np.frombuffer(samples, dtype=np.uint8).astype(
+                '<u2').tobytes()
+        chans[img_topics[topic]].append((rel, MsgScale(rng, None), samples))
+    total = sum(len(v) for v in chans.values())
+    if total and unscaled == total:
+        sys.exit('error: every recorded ping has sample_rate = 0 (bag predates '
+                 'the per-ping scale, issue #35) — render from debug/raw instead')
+    if unscaled:
+        print(f'warning: {unscaled}/{total} pings carry no scale '
+              f'(sample_rate = 0); they fall back to the median bin size')
+    # attach the published nadir line to the down-look pings (nearest-in-time)
+    if nadir and chans[DOWN]:
+        times = np.array([t for t, _r in nadir])
+        vals = np.array([r for _t, r in nadir])
+        chans[DOWN] = [
+            (t, MsgScale(sub.display_range_m,
+                         float(vals[np.argmin(np.abs(times - t))])), samp)
+            for t, sub, samp in chans[DOWN]]
     return chans
 
 
@@ -187,7 +271,7 @@ def render(chans, out, max_depth, across, vmin, vmax):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[1])
-    ap.add_argument('bag', help='path to an mcap bag recorded with debug_raw:=true')
+    ap.add_argument('bag', help='path to an mcap bag (debug/raw and/or sonar_image_* topics)')
     ap.add_argument('--start', type=float, default=0.0,
                     help='window start (s, relative to the first imagery packet)')
     ap.add_argument('--end', type=float, default=1e9,
@@ -201,12 +285,25 @@ def main(argv=None):
     ap.add_argument('--vmax', type=float, default=None,
                     help='raw-value white point (default a global 99.5%% percentile; '
                          'use 65535 for full uint16 range)')
+    ap.add_argument('--source', choices=('auto', 'raw', 'messages'), default='auto',
+                    help='input: raw = decode debug/raw with the driver own '
+                         'decoder; messages = render the published '
+                         'sonar_image_* (scale from sample_rate, bottom line '
+                         'from nadir_depth); auto prefers raw when present')
     args = ap.parse_args(argv)
 
     raw_topic = find_raw_topic(args.bag)
-    if raw_topic is None:
-        sys.exit('error: no */debug/raw topic in the bag — record with debug_raw:=true')
-    chans = read_pings(args.bag, raw_topic, args.start, args.end)
+    source = args.source
+    if source == 'auto':
+        source = 'raw' if raw_topic else 'messages'
+        print(f'source: {source} (auto)')
+    if source == 'raw':
+        if raw_topic is None:
+            sys.exit('error: no */debug/raw topic in the bag — record with '
+                     'debug_raw:=true, or use --source messages')
+        chans = read_pings(args.bag, raw_topic, args.start, args.end)
+    else:
+        chans = read_pings_messages(args.bag, args.start, args.end)
     if not chans[DOWN]:
         sys.exit('error: no down-look pings decoded in the window')
     print(f'down-look bin ~{_median_bin(chans[DOWN]) * 1000:.2f} mm/sample, '

--- a/garmin_sidescan/tools/sidescan_waterfall.py
+++ b/garmin_sidescan/tools/sidescan_waterfall.py
@@ -179,14 +179,19 @@ def read_pings_messages(bag, start, end):
     if unscaled:
         print(f'warning: {unscaled}/{total} pings carry no scale '
               f'(sample_rate = 0); they fall back to the median bin size')
-    # attach the published nadir line to the down-look pings (nearest-in-time)
+    # attach the published nadir line to the down-look pings: nearest-in-time
+    # via searchsorted on the (time-ordered) series -- O(N log M), not O(N*M)
     if nadir and chans[DOWN]:
         times = np.array([t for t, _r in nadir])
         vals = np.array([r for _t, r in nadir])
+        ping_t = np.array([t for t, _s, _x in chans[DOWN]])
+        hi = np.searchsorted(times, ping_t).clip(0, len(times) - 1)
+        lo = np.maximum(hi - 1, 0)
+        nearest = np.where(
+            np.abs(times[lo] - ping_t) <= np.abs(times[hi] - ping_t), lo, hi)
         chans[DOWN] = [
-            (t, MsgScale(sub.display_range_m,
-                         float(vals[np.argmin(np.abs(times - t))])), samp)
-            for t, sub, samp in chans[DOWN]]
+            (t, MsgScale(sub.display_range_m, float(vals[k])), samp)
+            for (t, sub, samp), k in zip(chans[DOWN], nearest)]
     return chans
 
 

--- a/garmin_sidescan/tools/verify_range_scale.py
+++ b/garmin_sidescan/tools/verify_range_scale.py
@@ -57,7 +57,7 @@ def read_bag(bag, start, end):
 
     raw_topic = None
     img_topics = {}
-    state_topic = None
+    state_candidates = []
     r = _reader(bag)
     for t in r.get_all_topics_and_types():
         if t.name.endswith('debug/raw'):
@@ -68,9 +68,14 @@ def read_bag(bag, start, end):
             # carry other RawSonarImage sources (e.g. the M3 multibeam)
             img_topics[t.name] = t.name.rsplit('_', 1)[-1]
         elif t.type == 'marine_radar_control_msgs/msg/RadarControlSet':
-            state_topic = t.name
+            state_candidates.append(t.name)
     if raw_topic is None:
         sys.exit('error: no */debug/raw topic in the bag — record with debug_raw:=true')
+    # The commanded-range mirror must be THIS driver's ~/state -- a bag can
+    # carry other RadarControlSet publishers (e.g. the radar). Match by the
+    # raw topic's own namespace.
+    ns = raw_topic[:-len('debug/raw')]
+    state_topic = next((n for n in state_candidates if n == ns + 'state'), None)
 
     asm = None                    # built once the generation vote resolves
     gen_votes = []

--- a/garmin_sidescan/tools/verify_range_scale.py
+++ b/garmin_sidescan/tools/verify_range_scale.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Verify the per-ping range scale + nadir depth against a recorded bag.
+
+Decodes a ``debug/raw`` stream with the SAME code the driver uses
+(``PingAssembler`` + per-run sub-header) and plots, on a shared time axis:
+
+  * per channel, the **sub-header v2 display range** -- the metric scale the
+    driver now publishes via ``sample_rate`` (issue #35); bracket (byte 13)
+    transitions are marked, so auto-range events are visible;
+  * the **v1 bottom range** the driver now publishes as ``nadir_depth``
+    (issue #16);
+  * what the bag's recorded ``sonar_image_*`` messages actually carried
+    (``sound_speed * bins / (2 * sample_rate)``, NaN when unavailable) and the
+    ``state`` topic's commanded-range mirror -- the before/after comparison.
+
+Interactive by default (zoom/pan with the matplotlib toolbar; try the Cod Rock
+auto-range transitions); ``--out FILE`` renders headless to a PNG instead.
+
+Requires a bag recorded with ``debug_raw:=true``. Run in a sourced workspace
+(needs ``garmin_sidescan`` on the path) with numpy + matplotlib available:
+
+    python3 verify_range_scale.py BAG [--start S] [--end S] [--out out.png]
+"""
+import argparse
+import sys
+
+from garmin_sidescan.decode import D807, EB07, echo_layer, PingAssembler
+import numpy as np
+from rclpy.serialization import deserialize_message
+import rosbag2_py
+from std_msgs.msg import UInt8MultiArray
+
+CHAN_NAMES = {0: 'port', 1: 'stbd', 2: 'down'}     # GCV-20 channel map
+
+
+def _reader(bag):
+    r = rosbag2_py.SequentialReader()
+    r.open(rosbag2_py.StorageOptions(uri=bag, storage_id='mcap'),
+           rosbag2_py.ConverterOptions(input_serialization_format='cdr',
+                                       output_serialization_format='cdr'))
+    return r
+
+
+def read_bag(bag, start, end):
+    """
+    Collect everything the figure needs, in one pass.
+
+    Returns ``(decoded, published, commanded)``:
+    ``decoded[ch] = [(t, v1, v2, bracket)]`` from the raw stream (driver-path
+    decode); ``published[side] = [(t, implied_range)]`` from the recorded
+    ``sonar_image_*`` messages; ``commanded = [(t, range_m)]`` from ``state``.
+    """
+    from marine_acoustic_msgs.msg import RawSonarImage
+    from marine_radar_control_msgs.msg import RadarControlSet
+
+    raw_topic = None
+    img_topics = {}
+    state_topic = None
+    r = _reader(bag)
+    for t in r.get_all_topics_and_types():
+        if t.name.endswith('debug/raw'):
+            raw_topic = t.name
+        elif t.type == 'marine_acoustic_msgs/msg/RawSonarImage':
+            img_topics[t.name] = t.name.rsplit('_', 1)[-1]
+        elif t.type == 'marine_radar_control_msgs/msg/RadarControlSet':
+            state_topic = t.name
+    if raw_topic is None:
+        sys.exit('error: no */debug/raw topic in the bag — record with debug_raw:=true')
+
+    asm = PingAssembler(echo_layer)
+    decoded = {}
+    published = {}
+    commanded = []
+    t0 = None
+    while r.has_next():
+        topic, data, ts = r.read_next()
+        if t0 is None:
+            t0 = ts
+        rel = (ts - t0) / 1e9
+        if rel > end + 2:
+            break
+        if topic == raw_topic:
+            b = bytes(deserialize_message(data, UInt8MultiArray).data)
+            if (b[:2] == EB07 and len(b) > 32) or b[:2] == D807:
+                for line in asm.feed(b, recv_time=rel):
+                    if line.subheader and start <= line.stamp <= end:
+                        s = line.subheader
+                        decoded.setdefault(line.channel, []).append(
+                            (line.stamp, s.bottom_range_m, s.display_range_m,
+                             s.bracket))
+        elif topic in img_topics and start <= rel <= end:
+            m = deserialize_message(data, RawSonarImage)
+            sv, rate = m.ping_info.sound_speed, m.sample_rate
+            rng = (sv * m.samples_per_beam / (2.0 * rate)
+                   if rate > 0 and sv > 0 else float('nan'))
+            published.setdefault(img_topics[topic], []).append((rel, rng))
+        elif topic == state_topic and start <= rel <= end:
+            m = deserialize_message(data, RadarControlSet)
+            for item in m.items:
+                if item.name == 'range':
+                    try:
+                        commanded.append((rel, float(item.value)))
+                    except ValueError:
+                        pass
+    return decoded, published, commanded
+
+
+def render(decoded, published, commanded, out):
+    """Two stacked panels: per-channel range scale (top), nadir depth (bottom)."""
+    import matplotlib
+    if out:
+        matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+
+    fig, (a1, a2) = plt.subplots(2, 1, figsize=(15, 9), sharex=True)
+
+    # top: the metric scale, per channel
+    for ch in sorted(decoded):
+        d = np.array([(t, v2) for t, _v1, v2, _br in decoded[ch]])
+        name = CHAN_NAMES.get(ch, f'ch{ch}')
+        a1.plot(d[:, 0], d[:, 1], '.', ms=2,
+                label=f'{name} sub-header v2 (driver publishes this)')
+        brackets = np.array([(t, br) for t, _v1, _v2, br in decoded[ch]])
+        steps = np.nonzero(np.diff(brackets[:, 1]))[0]
+        for i in steps:
+            a1.axvline(brackets[i + 1, 0], color='gray', lw=0.6, alpha=0.5)
+    for side in sorted(published):
+        p = np.array(published[side])
+        a1.plot(p[:, 0], p[:, 1], '+', ms=3, alpha=0.6,
+                label=f'{side} as recorded in bag (sample_rate)')
+    if commanded:
+        c = np.array(commanded)
+        a1.plot(c[:, 0], c[:, 1], drawstyle='steps-post', color='red', lw=1,
+                label='commanded-range mirror (state)')
+    a1.set_ylabel('range (m)')
+    a1.legend(loc='upper right', fontsize=8)
+    a1.set_title('per-channel display range: driver-path decode vs recorded '
+                 'messages (gray = byte-13 bracket transitions)')
+
+    # bottom: the nadir depth source (down-look v1; shared across channels)
+    for ch in sorted(decoded):
+        if CHAN_NAMES.get(ch) != 'down':
+            continue
+        d = np.array([(t, v1) for t, v1, _v2, _br in decoded[ch]])
+        a2.plot(d[:, 0], d[:, 1], '.', ms=2, color='tab:green',
+                label='down-look v1 -> nadir_depth')
+    a2.invert_yaxis()
+    a2.set_ylabel('bottom range (m)')
+    a2.set_xlabel('time (s, from first bag message)')
+    a2.legend(loc='lower left', fontsize=8)
+
+    fig.tight_layout()
+    if out:
+        fig.savefig(out, dpi=100)
+        print(f'saved {out}')
+    else:
+        plt.show()
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[1])
+    ap.add_argument('bag', help='path to an mcap bag recorded with debug_raw:=true')
+    ap.add_argument('--start', type=float, default=0.0,
+                    help='window start (s, relative to the first bag message)')
+    ap.add_argument('--end', type=float, default=1e9, help='window end (s)')
+    ap.add_argument('--out', default=None,
+                    help='write a PNG instead of opening the interactive window')
+    args = ap.parse_args(argv)
+
+    decoded, published, commanded = read_bag(args.bag, args.start, args.end)
+    if not decoded:
+        sys.exit('error: no pings with a parseable sub-header in the window')
+    for ch in sorted(decoded):
+        v2 = [v for _t, _v1, v, _br in decoded[ch]]
+        print(f'ch{ch} ({CHAN_NAMES.get(ch, "?")}): {len(v2)} pings, '
+              f'v2 {min(v2):.1f}-{max(v2):.1f} m')
+    render(decoded, published, commanded, args.out)
+
+
+if __name__ == '__main__':
+    main()

--- a/garmin_sidescan/tools/verify_range_scale.py
+++ b/garmin_sidescan/tools/verify_range_scale.py
@@ -6,8 +6,8 @@ Decodes a ``debug/raw`` stream with the SAME code the driver uses
 (``PingAssembler`` + per-run sub-header) and plots, on a shared time axis:
 
   * per channel, the **sub-header v2 display range** -- the metric scale the
-    driver now publishes via ``sample_rate`` (issue #35); bracket (byte 13)
-    transitions are marked, so auto-range events are visible;
+    driver now publishes via ``sample_rate`` (issue #35); v1 tag-length
+    transitions (the ex-"bracket", where device gain steps) are marked;
   * the **v1 bottom range** the driver now publishes as ``nadir_depth``
     (issue #16);
   * what the bag's recorded ``sonar_image_*`` messages actually carried
@@ -47,7 +47,7 @@ def read_bag(bag, start, end):
     Collect everything the figure needs, in one pass.
 
     Returns ``(decoded, published, commanded)``:
-    ``decoded[ch] = [(t, v1, v2, bracket)]`` from the raw stream (driver-path
+    ``decoded[ch] = [(t, v1, v2, v1_tag)]`` from the raw stream (driver-path
     decode); ``published[side] = [(t, implied_range)]`` from the recorded
     ``sonar_image_*`` messages; ``commanded = [(t, range_m)]`` from ``state``.
     """
@@ -96,7 +96,7 @@ def read_bag(bag, start, end):
                         s = line.subheader
                         decoded.setdefault(line.channel, []).append(
                             (line.stamp, s.bottom_range_m, s.display_range_m,
-                             s.bracket))
+                             s.v1_tag))
         elif topic in img_topics and start <= rel <= end:
             m = deserialize_message(data, RawSonarImage)
             sv, rate = m.ping_info.sound_speed, m.sample_rate
@@ -115,7 +115,7 @@ def read_bag(bag, start, end):
         if line.subheader and t0 is not None and start <= line.stamp <= end:
             s = line.subheader
             decoded.setdefault(line.channel, []).append(
-                (line.stamp, s.bottom_range_m, s.display_range_m, s.bracket))
+                (line.stamp, s.bottom_range_m, s.display_range_m, s.v1_tag))
     return decoded, published, commanded
 
 
@@ -149,7 +149,7 @@ def render(decoded, published, commanded, out):
     a1.set_ylabel('range (m)')
     a1.legend(loc='upper right', fontsize=8)
     a1.set_title('per-channel display range: driver-path decode vs recorded '
-                 'messages (gray = byte-13 bracket transitions)')
+                 'messages (gray = v1 tag-length transitions; gain steps)')
 
     # bottom: the nadir depth source (down-look v1; shared across channels)
     for ch in sorted(decoded):

--- a/garmin_sidescan/tools/verify_range_scale.py
+++ b/garmin_sidescan/tools/verify_range_scale.py
@@ -61,7 +61,10 @@ def read_bag(bag, start, end):
     for t in r.get_all_topics_and_types():
         if t.name.endswith('debug/raw'):
             raw_topic = t.name
-        elif t.type == 'marine_acoustic_msgs/msg/RawSonarImage':
+        elif (t.type == 'marine_acoustic_msgs/msg/RawSonarImage'
+              and 'sonar_image_' in t.name):
+            # name-filtered to the driver's own publishers: the same bag may
+            # carry other RawSonarImage sources (e.g. the M3 multibeam)
             img_topics[t.name] = t.name.rsplit('_', 1)[-1]
         elif t.type == 'marine_radar_control_msgs/msg/RadarControlSet':
             state_topic = t.name
@@ -75,7 +78,12 @@ def read_bag(bag, start, end):
     t0 = None
     while r.has_next():
         topic, data, ts = r.read_next()
+        # Anchor the window to the first raw datagram (same convention as
+        # sidescan_waterfall / replay_debug_raw, so windows are portable);
+        # messages before it are skipped.
         if t0 is None:
+            if topic != raw_topic:
+                continue
             t0 = ts
         rel = (ts - t0) / 1e9
         if rel > end + 2:
@@ -103,6 +111,11 @@ def read_bag(bag, start, end):
                         commanded.append((rel, float(item.value)))
                     except ValueError:
                         pass
+    for line in asm.flush():               # emit the final accumulated run
+        if line.subheader and t0 is not None and start <= line.stamp <= end:
+            s = line.subheader
+            decoded.setdefault(line.channel, []).append(
+                (line.stamp, s.bottom_range_m, s.display_range_m, s.bracket))
     return decoded, published, commanded
 
 

--- a/garmin_sidescan/tools/verify_range_scale.py
+++ b/garmin_sidescan/tools/verify_range_scale.py
@@ -25,7 +25,8 @@ Requires a bag recorded with ``debug_raw:=true``. Run in a sourced workspace
 import argparse
 import sys
 
-from garmin_sidescan.decode import D807, EB07, echo_layer, PingAssembler
+from garmin_sidescan.decode import (
+    D807, dark_layer, EB07, echo_layer, generation_from_layers, PingAssembler)
 import numpy as np
 from rclpy.serialization import deserialize_message
 import rosbag2_py
@@ -71,7 +72,8 @@ def read_bag(bag, start, end):
     if raw_topic is None:
         sys.exit('error: no */debug/raw topic in the bag — record with debug_raw:=true')
 
-    asm = PingAssembler(echo_layer)
+    asm = None                    # built once the generation vote resolves
+    gen_votes = []
     decoded = {}
     published = {}
     commanded = []
@@ -90,6 +92,17 @@ def read_bag(bag, start, end):
             break
         if topic == raw_topic:
             b = bytes(deserialize_message(data, UInt8MultiArray).data)
+            if asm is None:
+                # Pick the per-packet echo extractor from the stream itself
+                # (GCV-10 dark layer vs GCV-20 first layer), voted like the
+                # driver so one odd packet can't misclassify the bag.
+                g = generation_from_layers(b)
+                if g is not None:
+                    gen_votes.append(g)
+                if len(gen_votes) < 5:
+                    continue
+                gen = max(set(gen_votes), key=gen_votes.count)
+                asm = PingAssembler(dark_layer if gen == 'gcv10' else echo_layer)
             if (b[:2] == EB07 and len(b) > 32) or b[:2] == D807:
                 for line in asm.feed(b, recv_time=rel):
                     if line.subheader and start <= line.stamp <= end:
@@ -111,7 +124,7 @@ def read_bag(bag, start, end):
                         commanded.append((rel, float(item.value)))
                     except ValueError:
                         pass
-    for line in asm.flush():               # emit the final accumulated run
+    for line in (asm.flush() if asm else []):   # emit the final accumulated run
         if line.subheader and t0 is not None and start <= line.stamp <= end:
             s = line.subheader
             decoded.setdefault(line.channel, []).append(
@@ -160,7 +173,7 @@ def render(decoded, published, commanded, out):
                 label='down-look v1 -> nadir_depth')
     a2.invert_yaxis()
     a2.set_ylabel('bottom range (m)')
-    a2.set_xlabel('time (s, from first bag message)')
+    a2.set_xlabel('time (s, from first raw datagram)')
     a2.legend(loc='lower left', fontsize=8)
 
     fig.tight_layout()
@@ -175,7 +188,7 @@ def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[1])
     ap.add_argument('bag', help='path to an mcap bag recorded with debug_raw:=true')
     ap.add_argument('--start', type=float, default=0.0,
-                    help='window start (s, relative to the first bag message)')
+                    help='window start (s, relative to the first raw datagram)')
     ap.add_argument('--end', type=float, default=1e9, help='window end (s)')
     ap.add_argument('--out', default=None,
                     help='write a PNG instead of opening the interactive window')


### PR DESCRIPTION
## Summary

The driver's published `RawSonarImage.sample_rate` derived its metric scale only from the commanded-range mirror — absent (`0.0`) whenever the driver hadn't commanded a range (every ping of the 2026-06-11 bag) and a flat wrong value under hardware auto-range (the 2026-06-10 Cod Rock bag held `60.0` while the true side-scan swath stepped 47.8 → 30.4 → 50.4 → 29.8 → 48.9 m). The per-ping sub-header **v2** is each channel's own true display range (verified to track both Cod Rock auto-range transitions); the driver now publishes from it.

The same sub-header's **v1** is the device's real per-ping bottom range (M3-validated to ~1%), so this also reinstates the `~/nadir_depth` `sensor_msgs/Range` output that was removed with the disproven `0xe4`-status reading — closing the nadir-depth question for real this time.

Closes #35. Closes #16. Supersedes #32 deliverable A (commented there); #32 narrows to optionally pinning auto-range.

## Changes

- **`decode.py`** — `PingAssembler` returns `ScanLine(channel, samples, stamp, subheader)`, tagging every run with its own parsed sub-header; pure `derive_sample_rate()` with the fallback chain v2 → commanded range (side-scan only) → `sample_rate_hz` → 0 (unavailable).
- **`node.py`** — `sample_rate` from the ping's own v2; the down-look never takes the commanded fallback (it would be a confidently-wrong ~2× scale); `~/nadir_depth` from v1, per-ping, in the +X-down `<frame_id>_nadir` frame, `max_range` = the ping's own water-column extent.
- **Tools** — `replay_debug_raw.py` (replay a `debug/raw` bag onto the imagery multicast, loopback-default, for hardware-free end-to-end driver testing) and `verify_range_scale.py` (interactive before/after plot: decoded v1/v2/bracket vs the bag's recorded scale).
- **Docs** — `gcv_protocol.md` §3.5 stale conclusion corrected (the active range IS passively available — in the imagery sub-header, not the config stream), §3.4/§5 nadir-depth resolution; README topics/params.

## Verification

- 64/64 tests (new: per-run sub-header attachment on the real GCV-20 capture, GCV-10 no-parse fallback, per-channel derivation round-trip, down-channel fallback exclusion, nadir Range mapping); ament flake8/pep257 clean.
- **End-to-end**: replayed the 2026-06-10 Cod Rock bag (t150–180, spanning an auto-range step) through the **built driver** on loopback; a live consumer recovered port/stbd ranges **{47.8, 30.4} m** across the transition, down **{10.8, 11.2} m** (its own water-column range), and `nadir_depth` **7.62–7.76 m** on the shoal — values the old driver reported as a flat 60 m / nothing.
- Pre-push `/review-code` (Standard): 1 must-fix + 7 suggestions found and addressed (`1c91f34`); review log in `.agent/work-plans/issue-35/progress.md`.

## Platform follow-up

rolker/unh_echoboats_project11#254 — add the `_nadir` URDF frame on bizzy, record `nadir_depth`, set the `freq_*_hz` params.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
