### PR TITLE
garmin_sidescan: stop splitting pings on the d807 telemetry sub-form; publish water temperature

### DIFF
--- a/.agent/work-plans/issue-37/progress.md
+++ b/.agent/work-plans/issue-37/progress.md
@@ -34,3 +34,24 @@ bag_2026-06-12T16.06.52 drops short pings from 140/82/122 to 2/0/0 per channel
 flake8 + ament_pep257 clean; pytest 73 tests, 0 failures (new: real-capture-frame
 decode, non-finite rejection, truncated-flush, temperature_plausible,
 temperature_publish_due, telemetry-mid-run assembles whole).
+
+## Local Review (Pre-Push, 2nd pass)
+**Status**: complete
+**When**: 2026-06-13 10:05 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+**Branch**: feature/issue-37 at `ea7f561`
+**Depth**: Standard, concurrency/lifecycle focus (sole gate — Copilot quota exhausted until end of June 2026)
+**Must-fix**: 0 | **Suggestions**: 3 (addressed)
+
+Second independent fresh-context adversarial pass (no must-fix). Confirmed: no
+intra-node race (single rx thread mutates the dedup state; publisher built before
+thread start), telemetry frame no-ops the assembler cleanly, sub-form tags
+unambiguous, variance=0.0 is the spec "unknown" sentinel.
+
+### Findings
+- [x] (suggestion) telemetry dropped during generation-detect warmup — hoisted the decode above the assembler-None gate
+- [x] (suggestion) heartbeat cadence coarser than documented (evaluated on arrival) — softened docstring
+- [x] (suggestion) backward clock jump (sim/bag-loop) briefly suppresses heartbeat — added an awareness comment
+
+Tests: 73 pass, 0 failures.

--- a/.agent/work-plans/issue-37/progress.md
+++ b/.agent/work-plans/issue-37/progress.md
@@ -1,0 +1,36 @@
+---
+issue: 37
+---
+
+# Issue #37 — garmin_sidescan: ping assembler splits pings on the d807 telemetry sub-form (020c = water temperature)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-13 09:30 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved (with hardening applied)
+
+**Branch**: feature/issue-37 at `04fd9dd`
+**Mode**: pre-push
+**Depth**: Standard (reason: driver decode/assembly change + new publisher, ~193 lines)
+**Static analysis**: run via colcon (flake8/pep257/pytest) — clean
+**Copilot Adversarial**: skipped (monthly quota exceeded)
+**Must-fix**: 1 (addressed) | **Suggestions**: 2 (addressed)
+
+Independent fresh-context Claude adversarial pass. The split-on-020c fix and the
+temperature decode/publish are sound; the reviewer confirmed the tag discriminator
+is unambiguous (a delimiter's field2 tag 0x10|L can never read as 0x0c), the
+Time-math units are correct, and the regression test genuinely distinguishes
+old (2 fragments) from new (1 whole ping). End-to-end re-decode of
+bag_2026-06-12T16.06.52 drops short pings from 140/82/122 to 2/0/0 per channel
+(residual = genuine UDP loss); 7,692 temperatures decode at 25.2-29.0 degC.
+
+### Findings
+- [x] (must-fix) corrupt telemetry → NaN/inf published, and NaN defeats dedup (`nan != nan`) — `decode.py marker_temperature_c` now drops non-finite; `node.py _emit_temperature` gates an implausible window
+- [x] (suggestion) truncated `02 0c` frame neither flushed nor decoded — split `_is_telemetry_marker` (structural) from validity so a short frame flushes (`decode.py is_run_delimiter`)
+- [x] (suggestion) "next channel backstops a dropped delimiter" stated as a guarantee — softened to the observed channel-cycling behaviour (`decode.py feed` comment)
+
+### Static analysis / tests
+flake8 + ament_pep257 clean; pytest 73 tests, 0 failures (new: real-capture-frame
+decode, non-finite rejection, truncated-flush, temperature_plausible,
+temperature_publish_due, telemetry-mid-run assembles whole).

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -154,13 +154,23 @@ Verified per-marker against both neighbours on the full 2026-06-11 capture:
 channel *and* v1 exactly; the residual is packet loss plus the sub-form below
 parsed as if common-form.
 
-- A 16-byte sub-form (`02 0c <4-byte field1 value> 19 <channel>`, 780 frames
-  ≈ 1.2 %, in channel triplets ~every 1.4 s) carries **field1 with a 4-byte
-  value instead of field2** — the value's meaning is open (§6).
+- A 16-byte **telemetry** sub-form (`02 0c <float32 LE> 19 <channel>`,
+  ≈ 1.2 % of markers, in channel triplets ~0.7 Hz) carries **field1 as an
+  IEEE-754 float32 = the transducer surface water temperature (°C)**. The same
+  value appears on all three channels of a triplet (a device-wide scalar).
+  Validated two ways, each within one water body / day: against an AML CTD cast
+  (2026-06-10 pier, 020c 15.5 °C vs cast surface 16.0–16.5 °C) and against the
+  boat's own sound-velocity sensor (2026-06-12, the temperature predicts the
+  measured sound speed within 1–3 m/s). It reads the warm surface skin the
+  hull transducer sits in, not the bulk water.
 
-The assembler treats any `d807` as "flush the current channel's
-accumulation"; the channel tag and range fields are not needed for assembly
-(the run's own `eb07` sub-headers carry the same fields authoritatively).
+The delimiter sub-form ends a channel run; the telemetry sub-form does **not** —
+it is interleaved mid-run, so flushing on any `d807` (the original behaviour)
+split single pings into two fragments. The assembler now flushes only on the
+delimiter sub-form (`decode.is_run_delimiter`) and decodes the telemetry
+temperature (`decode.marker_temperature_c`); the run's own `eb07` sub-headers
+carry the channel/range authoritatively, and the next channel's first packet
+backstops a dropped delimiter (the stream cycles channels). See issue #37.
 
 ---
 
@@ -435,8 +445,9 @@ bottom range and v2 scaling (§4.1) and disproved the `0xe4`-as-depth reading
 - **`0x00`-status offsets 17–23**: constant `ae 05 c0 75 ae 05 c0` on the
   boat, but cycling values with ASCII fragments on the bench — windowed
   text/diagnostic stream? Sequence-reassemble the 06-05 bench frames.
-- **`d807` field1 sub-form** (`02 0c <4 raw bytes> 19 <ch>`, ~1.2 % of
-  markers, periodic ~0.7 Hz per channel) — the 4-byte value's meaning.
+- ~~**`d807` field1 sub-form** (`02 0c <4 raw bytes> 19 <ch>`) — the 4-byte
+  value's meaning.~~ **Resolved (issue #37): float32 surface water temperature
+  (°C).** See §3.C.
 - **`0xBEEF` command high half** — required by the device, or cosmetic? One
   TCP experiment (send a `0x0000`-high command); don't test on a live survey
   unit.

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -29,6 +29,7 @@ sub-header, so the driver takes frequency from configuration and stamps pings
 with their receive time (see node.py).
 """
 from collections import namedtuple
+import math
 import struct
 
 # Frame ids (low half of the u32-LE message id; the high half is 0x0000 on
@@ -106,17 +107,31 @@ def status_transmitting(payload):
     return None
 
 
+def _is_telemetry_marker(payload):
+    """
+    Return whether a ``d807`` frame is a complete telemetry sub-form.
+
+    Structural test only (tag + enough bytes to hold the float32); independent
+    of whether the decoded value is sane.  A *truncated* telemetry frame fails
+    this, so it falls through to a flush in :func:`is_run_delimiter` rather than
+    being silently swallowed.
+    """
+    return (payload[:2] == D807
+            and len(payload) >= D807_ENVELOPE + 6
+            and payload[D807_ENVELOPE:D807_ENVELOPE + 2] == D807_TELEMETRY_TAG)
+
+
 def is_run_delimiter(payload):
     """
     Return whether a ``d807`` frame ends the current channel's packet run.
 
     Both ``d807`` sub-forms (delimiter, telemetry) carry the magic, but only the
     delimiter is a run boundary.  Returns True for the delimiter and for any
-    unrecognised ``d807`` sub-form (conservative: an unknown marker flushes, as
-    it always did); False only for the known temperature-telemetry sub-form.
+    unrecognised or truncated ``d807`` sub-form (conservative: an unknown marker
+    flushes, as it always did); False only for a complete temperature-telemetry
+    sub-form.
     """
-    return (payload[:2] == D807
-            and payload[D807_ENVELOPE:D807_ENVELOPE + 2] != D807_TELEMETRY_TAG)
+    return payload[:2] == D807 and not _is_telemetry_marker(payload)
 
 
 def marker_temperature_c(payload):
@@ -127,13 +142,14 @@ def marker_temperature_c(payload):
     field1 carries an IEEE-754 float32 surface water temperature.  Validated
     against an AML CTD cast (same water/day, within ~1 deg C) and the boat's own
     sound-velocity sensor (predicted vs measured sound speed within 1-3 m/s);
-    see issue #37 and gcv_protocol.md section 3.C.
+    see issue #37 and gcv_protocol.md section 3.C.  A non-finite value (a
+    corrupt frame) returns None -- it is not a usable reading, and NaN would
+    otherwise defeat the publisher's change-detection (``nan != nan``).
     """
-    if (payload[:2] != D807
-            or len(payload) < D807_ENVELOPE + 6
-            or payload[D807_ENVELOPE:D807_ENVELOPE + 2] != D807_TELEMETRY_TAG):
+    if not _is_telemetry_marker(payload):
         return None
-    return struct.unpack_from('<f', payload, D807_ENVELOPE + 2)[0]
+    value = struct.unpack_from('<f', payload, D807_ENVELOPE + 2)[0]
+    return value if math.isfinite(value) else None
 
 
 # Render-layer header signatures (little-endian sample pairs).
@@ -506,10 +522,12 @@ class PingAssembler:
         if payload[:2] == D807:
             # The delimiter sub-form ends the run; the temperature-telemetry
             # sub-form is interleaved mid-run and must NOT flush, or one ping
-            # is split into two fragments (issue #37). The next channel's first
-            # packet (channel change, below) independently flushes the run, so a
-            # dropped delimiter can't merge two consecutive pings -- the stream
-            # cycles channels, so the same channel never repeats back-to-back.
+            # is split into two fragments (issue #37). A dropped delimiter is
+            # backstopped by the next channel's first packet (channel change,
+            # below) -- the stream is observed to cycle channels, so consecutive
+            # runs differ in channel; if a future firmware ran the same channel
+            # back-to-back, a dropped delimiter between them would merge two
+            # pings (the MAX_SCAN_BYTES guard then caps the runaway).
             if is_run_delimiter(payload):
                 self._emit(out)
                 self._cur_ch = None

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -29,17 +29,25 @@ sub-header, so the driver takes frequency from configuration and stamps pings
 with their receive time (see node.py).
 """
 from collections import namedtuple
+import struct
 
 # Frame ids (low half of the u32-LE message id; the high half is 0x0000 on
 # every bus frame, so they read as "<magic> 00 00" -- see docs/gcv_protocol.md
 # section 1 for the envelope).
 EB07 = b'\xeb\x07'
-# Channel marker. Payload `02 <field2 tag + v1 varint> 19 <channel>` -- a
-# two-field record tagging an adjacent run's channel and carrying that run's
-# bottom range (markers bracket runs in close/open pairs; see gcv_protocol.md
-# section 3.C). The assembler only uses it as a flush signal: the run's own
-# eb07 sub-headers carry the same fields authoritatively.
+# Channel marker. Two sub-forms share the d807 magic (see gcv_protocol.md
+# section 3.C):
+#   * delimiter (`02 | 0x10|L v1 | 19 <channel>`) -- ends a channel's packet
+#     run; markers bracket runs in close/open pairs.  The run's own eb07
+#     sub-headers carry the channel/range authoritatively, so the assembler
+#     uses this only as a flush signal.
+#   * telemetry (`02 0c <float32 LE> 19 <channel>`, 16-byte frame) -- the
+#     transducer water temperature, interleaved as a per-channel triplet
+#     ~0.7 Hz.  It is NOT a run boundary: treating it as one tore single pings
+#     into two fragments (issue #37).  See :func:`marker_temperature_c`.
 D807 = b'\xd8\x07'
+D807_ENVELOPE = 8                # d8 07 00 00 <u32-LE payload len>, then record
+D807_TELEMETRY_TAG = b'\x02\x0c'  # record header of the temperature sub-form
 STATUS_MAGIC = b'\x8e\x03'       # GCV status broadcast (239.254.2.2:50050)
 # The :50050 stream multiplexes two 34-byte sub-types, discriminated by the
 # payload byte at offset 9 (see docs/gcv_protocol.md):
@@ -96,6 +104,36 @@ def status_transmitting(payload):
     if sub == 0x01:
         return False
     return None
+
+
+def is_run_delimiter(payload):
+    """
+    Return whether a ``d807`` frame ends the current channel's packet run.
+
+    Both ``d807`` sub-forms (delimiter, telemetry) carry the magic, but only the
+    delimiter is a run boundary.  Returns True for the delimiter and for any
+    unrecognised ``d807`` sub-form (conservative: an unknown marker flushes, as
+    it always did); False only for the known temperature-telemetry sub-form.
+    """
+    return (payload[:2] == D807
+            and payload[D807_ENVELOPE:D807_ENVELOPE + 2] != D807_TELEMETRY_TAG)
+
+
+def marker_temperature_c(payload):
+    """
+    Return the ``d807`` telemetry water temperature (deg C), or None otherwise.
+
+    The telemetry sub-form is the 16-byte frame ``02 0c <float32 LE> 19 <ch>``:
+    field1 carries an IEEE-754 float32 surface water temperature.  Validated
+    against an AML CTD cast (same water/day, within ~1 deg C) and the boat's own
+    sound-velocity sensor (predicted vs measured sound speed within 1-3 m/s);
+    see issue #37 and gcv_protocol.md section 3.C.
+    """
+    if (payload[:2] != D807
+            or len(payload) < D807_ENVELOPE + 6
+            or payload[D807_ENVELOPE:D807_ENVELOPE + 2] != D807_TELEMETRY_TAG):
+        return None
+    return struct.unpack_from('<f', payload, D807_ENVELOPE + 2)[0]
 
 
 # Render-layer header signatures (little-endian sample pairs).
@@ -466,8 +504,15 @@ class PingAssembler:
         """Consume one datagram payload; return any completed scan lines."""
         out = []
         if payload[:2] == D807:
-            self._emit(out)
-            self._cur_ch = None
+            # The delimiter sub-form ends the run; the temperature-telemetry
+            # sub-form is interleaved mid-run and must NOT flush, or one ping
+            # is split into two fragments (issue #37). The next channel's first
+            # packet (channel change, below) independently flushes the run, so a
+            # dropped delimiter can't merge two consecutive pings -- the stream
+            # cycles channels, so the same channel never repeats back-to-back.
+            if is_run_delimiter(payload):
+                self._emit(out)
+                self._cur_ch = None
         elif payload[:2] == EB07 and len(payload) > MIN_DATA_LEN:
             ch = payload[CHANNEL_OFFSET]
             block = self._extract(payload)

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -156,6 +156,18 @@ def range_in_bounds(meters, range_min, range_max):
     return range_min <= meters <= range_max
 
 
+# Plausible surface-water-temperature window (deg C). A finite-but-absurd
+# float from a corrupt telemetry frame (decode already drops non-finite) is
+# gated out before publishing, mirroring the nadir-range validity gate -- a
+# per-cycle gap is honest, a wild value is noise downstream.
+WATER_TEMP_MIN_C, WATER_TEMP_MAX_C = -5.0, 50.0
+
+
+def temperature_plausible(temp_c):
+    """Return whether a water-temperature reading (deg C) is within sane bounds."""
+    return WATER_TEMP_MIN_C <= temp_c <= WATER_TEMP_MAX_C
+
+
 def temperature_publish_due(temp_c, last_c, elapsed_s, heartbeat_s=2.0):
     """
     Whether a water-temperature reading should be published.
@@ -854,6 +866,10 @@ class GarminSidescanNode(Node):
                     self._nadir_fov, v2))
 
     def _emit_temperature(self, temp_c, stamp):
+        # A corrupt frame can decode to a finite-but-absurd value (decode drops
+        # non-finite already); gate it out rather than publish noise.
+        if not temperature_plausible(temp_c):
+            return
         # Collapse a per-channel triplet to one message; heartbeat a steady
         # value (see temperature_publish_due).
         elapsed = (float('inf') if self._last_temp_t is None

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -174,10 +174,13 @@ def temperature_publish_due(temp_c, last_c, elapsed_s, heartbeat_s=2.0):
 
     The d807 telemetry marker repeats the same value on each channel of a
     ~0.7 Hz triplet, so a changed value publishes immediately (collapsing the
-    triplet to one message), and an unchanged value publishes only once per
-    ``heartbeat_s`` so the topic still ticks for consumers.  ``last_c`` is None
-    before the first reading (always due); ``elapsed_s`` is the time since the
-    last publish.
+    triplet to one message), and an unchanged value publishes on the first
+    reading whose arrival is at least ``heartbeat_s`` after the last publish so
+    the topic still ticks for consumers.  Because this is evaluated only when a
+    frame arrives (~every 1.4 s for a steady reading), the effective steady-state
+    cadence is the next triplet past ``heartbeat_s``, not exactly ``heartbeat_s``.
+    ``last_c`` is None before the first reading (always due); ``elapsed_s`` is the
+    time since the last publish (``inf`` for the first reading).
     """
     if last_c is None or temp_c != last_c:
         return True
@@ -752,6 +755,13 @@ class GarminSidescanNode(Node):
                 # Full UDP payload (magic + channel + all layers) so the bag is
                 # re-decodable offline. Published as-is; bag timestamps give timing.
                 self._pub_raw.publish(UInt8MultiArray(data=payload))
+            now = self.get_clock().now()
+            # Water-temperature telemetry has no dependency on the imagery
+            # assembler, so decode it before the generation-detect gate below --
+            # otherwise the topic stays silent through auto-detect warmup.
+            temp_c = marker_temperature_c(payload)
+            if temp_c is not None:
+                self._emit_temperature(temp_c, now)
             detected = self._detect_generation(payload)
             self._classify_beam(payload)
             if self._assembler is None:
@@ -765,10 +775,6 @@ class GarminSidescanNode(Node):
                 self.get_logger().warn(
                     f'device={self._device} but packet geometry looks like '
                     f'{detected}; imagery decode is likely wrong')
-            now = self.get_clock().now()
-            temp_c = marker_temperature_c(payload)
-            if temp_c is not None:
-                self._emit_temperature(temp_c, now)
             for line in self._assembler.feed(payload, now):
                 self._emit_ping(line)
         if self._assembler is not None:
@@ -871,7 +877,9 @@ class GarminSidescanNode(Node):
         if not temperature_plausible(temp_c):
             return
         # Collapse a per-channel triplet to one message; heartbeat a steady
-        # value (see temperature_publish_due).
+        # value (see temperature_publish_due). On a backward clock jump (sim
+        # reset / bag loop) elapsed goes negative: a changed value still
+        # publishes, a steady one resumes heartbeating once the clock recovers.
         elapsed = (float('inf') if self._last_temp_t is None
                    else (stamp - self._last_temp_t).nanoseconds * 1e-9)
         if not temperature_publish_due(temp_c, self._last_temp_c, elapsed):

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -6,7 +6,9 @@ Receives the GCV imagery multicast, decodes per-ping sidescan scan lines (see
 ``marine_acoustic_msgs/RawSonarImage`` (one publisher per channel, single
 beam) with the metric scale (``sample_rate``) derived from each ping's own
 sub-header display range (v2), plus the per-ping nadir bottom range
-(sub-header v1) as a ``sensor_msgs/Range`` on ``~/nadir_depth``.  Controls
+(sub-header v1) as a ``sensor_msgs/Range`` on ``~/nadir_depth`` and the
+transducer surface water temperature (the d807 telemetry marker) as a
+``sensor_msgs/Temperature`` on ``~/water_temperature``.  Controls
 transmit on/off and range over the GCV TCP command port
 (see :mod:`garmin_sidescan.commands`).  Rendering is left to downstream tools
 (``rqt_sonar_waterfall``); a ``debug_raw`` parameter can publish the raw UDP
@@ -31,7 +33,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from rosidl_runtime_py.utilities import get_message
-from sensor_msgs.msg import Range
+from sensor_msgs.msg import Range, Temperature
 from std_msgs.msg import Bool, String, UInt8MultiArray
 from std_srvs.srv import SetBool
 
@@ -45,8 +47,8 @@ from .commands import (
 )
 from .decode import (
     CHANNEL_OFFSET, dark_layer, derive_sample_rate, EB07, echo_layer,
-    generation_from_layers, is_water_column, MIN_DATA_LEN, PingAssembler,
-    status_transmitting)
+    generation_from_layers, is_water_column, marker_temperature_c, MIN_DATA_LEN,
+    PingAssembler, status_transmitting)
 
 # Auxiliary GCV multicast streams the driver can listen to. The imagery group
 # is a parameter (mcast_group/port); these two are fixed by the GCV protocol.
@@ -152,6 +154,22 @@ def watchdog_action(*, safety_enabled, transmitting, has_sv_topic,
 def range_in_bounds(meters, range_min, range_max):
     """Return whether a requested range (m) is within the configured limits."""
     return range_min <= meters <= range_max
+
+
+def temperature_publish_due(temp_c, last_c, elapsed_s, heartbeat_s=2.0):
+    """
+    Whether a water-temperature reading should be published.
+
+    The d807 telemetry marker repeats the same value on each channel of a
+    ~0.7 Hz triplet, so a changed value publishes immediately (collapsing the
+    triplet to one message), and an unchanged value publishes only once per
+    ``heartbeat_s`` so the topic still ticks for consumers.  ``last_c`` is None
+    before the first reading (always due); ``elapsed_s`` is the time since the
+    last publish.
+    """
+    if last_c is None or temp_c != last_c:
+        return True
+    return elapsed_s >= heartbeat_s
 
 
 class GarminSidescanNode(Node):
@@ -294,6 +312,11 @@ class GarminSidescanNode(Node):
         self._detected_gen = None
         self._gen_votes = {}          # structural generation votes (see _detect_generation)
         self._geom_warned = False
+        # Water-temperature dedup: the d807 telemetry marker repeats the same
+        # reading on each channel of a triplet; publish one per distinct value,
+        # with a heartbeat so a steady reading still ticks (see _emit_temperature).
+        self._last_temp_c = None
+        self._last_temp_t = None
         # Sample format, set when the assembler is built from the generation
         # (GCV-20 = 16-bit uint16-LE, GCV-10 = 8-bit). Defaults are harmless
         # until then; no pings are emitted before the assembler exists.
@@ -319,6 +342,11 @@ class GarminSidescanNode(Node):
         # (see build_nadir_range / the _nadir frame). Per-ping sensor data, so
         # the imagery QoS, not latched.
         self._pub_depth = self.create_publisher(Range, '~/nadir_depth', img_qos)
+        # Transducer surface water temperature decoded from the d807 telemetry
+        # marker (per-channel triplet ~0.7 Hz; deduplicated to one reading per
+        # cycle). Validated against an AML CTD cast + the boat's SVS (issue #37).
+        self._pub_temperature = self.create_publisher(
+            Temperature, '~/water_temperature', img_qos)
         # Raw-payload debug capture (only published when debug_raw is true) --
         # one topic per GCV multicast stream so a single bag is fully
         # re-decodable offline (imagery + status + chartplotter config).
@@ -726,6 +754,9 @@ class GarminSidescanNode(Node):
                     f'device={self._device} but packet geometry looks like '
                     f'{detected}; imagery decode is likely wrong')
             now = self.get_clock().now()
+            temp_c = marker_temperature_c(payload)
+            if temp_c is not None:
+                self._emit_temperature(temp_c, now)
             for line in self._assembler.feed(payload, now):
                 self._emit_ping(line)
         if self._assembler is not None:
@@ -821,6 +852,23 @@ class GarminSidescanNode(Node):
                 self._pub_depth.publish(build_nadir_range(
                     v1, self._nadir_frame_id, line.stamp.to_msg(),
                     self._nadir_fov, v2))
+
+    def _emit_temperature(self, temp_c, stamp):
+        # Collapse a per-channel triplet to one message; heartbeat a steady
+        # value (see temperature_publish_due).
+        elapsed = (float('inf') if self._last_temp_t is None
+                   else (stamp - self._last_temp_t).nanoseconds * 1e-9)
+        if not temperature_publish_due(temp_c, self._last_temp_c, elapsed):
+            return
+        self._last_temp_c = temp_c
+        self._last_temp_t = stamp
+        msg = Temperature()
+        msg.header.stamp = stamp.to_msg()
+        # The transducer's own sensor -- tag it with the base sensor frame.
+        msg.header.frame_id = self._frame_id
+        msg.temperature = float(temp_c)
+        msg.variance = 0.0          # unknown (0 = "variance unknown" per the spec)
+        self._pub_temperature.publish(msg)
 
     def _make_sonar_msg(self, side, samples, stamp, sub=None):
         msg = RawSonarImage()

--- a/garmin_sidescan/test/test_decode.py
+++ b/garmin_sidescan/test/test_decode.py
@@ -431,6 +431,24 @@ def test_marker_temperature_c_decodes_float32():
     assert marker_temperature_c(bytes([0xd8, 0x07])) is None        # truncated
 
 
+def test_marker_temperature_c_decodes_real_capture_frame():
+    # A telemetry frame captured verbatim from bag_2026-06-12T16.06.52 (pins the
+    # real byte layout, not just the synthetic builder): 02 0c <f32> 19 <ch>.
+    real = bytes.fromhex('d80700000800000002 0c057fe741 1900'.replace(' ', ''))
+    assert len(real) == 16
+    assert abs(marker_temperature_c(real) - 28.937) < 1e-2
+
+
+def test_marker_temperature_c_rejects_non_finite():
+    # A corrupt telemetry frame decoding to NaN/inf is not a usable reading --
+    # None keeps it off the wire and out of the publisher's change-detection.
+    nan_frame = (bytes([0xd8, 0x07, 0, 0]) + struct.pack('<I', 8)
+                 + b'\x02\x0c' + b'\xff\xff\xff\xff' + b'\x19' + bytes([0]))
+    assert marker_temperature_c(nan_frame) is None
+    # ...but it is still structurally telemetry, so it must NOT flush the run.
+    assert is_run_delimiter(nan_frame) is False
+
+
 def test_is_run_delimiter_distinguishes_subforms():
     # The delimiter sub-form ends a run; the telemetry sub-form does not.
     assert is_run_delimiter(_d807_delimiter(b'\xce\x57', channel=2)) is True
@@ -438,6 +456,11 @@ def test_is_run_delimiter_distinguishes_subforms():
     # an unrecognised/bare d807 still flushes (conservative); eb07 never does
     assert is_run_delimiter(bytes([0xd8, 0x07])) is True
     assert is_run_delimiter(bytes([0xeb, 0x07, 0, 0]) + bytes(40)) is False
+    # a *truncated* telemetry frame (tag matches but too short for the float)
+    # falls through to a flush rather than being silently swallowed
+    truncated = bytes([0xd8, 0x07, 0, 0]) + struct.pack('<I', 8) + b'\x02\x0c\x05'
+    assert is_run_delimiter(truncated) is True
+    assert marker_temperature_c(truncated) is None
 
 
 def test_assembler_keeps_ping_whole_across_telemetry_marker():

--- a/garmin_sidescan/test/test_decode.py
+++ b/garmin_sidescan/test/test_decode.py
@@ -11,10 +11,24 @@ import struct
 
 from garmin_sidescan.decode import (
     dark_layer, decode_leb128, derive_sample_rate, echo_layer, FH,
-    generation_from_layers, is_water_column, parse_downlook_subheader,
+    generation_from_layers, is_run_delimiter, is_water_column,
+    marker_temperature_c, parse_downlook_subheader,
     parse_subheader, PingAssembler, SH, status_subtype, status_transmitting,
     strip_first_layer_trailer, strip_leading_ping_header, Subheader,
     subheader_bottom_range_m, TRAILER_MAGIC)
+
+
+def _d807_telemetry(temp_c, channel):
+    """Build a 16-byte d807 telemetry frame: 02 0c <f32 LE> 19 <ch>."""
+    return (bytes([0xd8, 0x07, 0, 0]) + struct.pack('<I', 8)
+            + b'\x02\x0c' + struct.pack('<f', temp_c) + b'\x19' + bytes([channel]))
+
+
+def _d807_delimiter(v1, channel):
+    """Build a d807 run delimiter: 02 <0x10|len(v1)> <v1 varint> 19 <ch>."""
+    body = b'\x02' + bytes([0x10 | len(v1)]) + v1 + b'\x19' + bytes([channel])
+    return bytes([0xd8, 0x07, 0, 0]) + struct.pack('<I', len(body)) + body
+
 
 FIXTURE = os.path.join(os.path.dirname(__file__), 'fixtures', 'gcv_real_pings.bin')
 # Real GCV-20 capture (2026-06-09 wet test, issue #26): a contiguous window of
@@ -402,6 +416,47 @@ def test_subheader_grammar_tags_encode_varint_length_on_both_fixtures():
                 i = end
             checked += 1
     assert checked >= 60                  # both fixtures contribute
+
+
+def test_marker_temperature_c_decodes_float32():
+    # 020c telemetry sub-form carries a float32 LE water temperature (deg C).
+    frame = _d807_telemetry(28.94, channel=2)
+    assert len(frame) == 16
+    assert abs(marker_temperature_c(frame) - 28.94) < 1e-3
+    # the channel byte does not affect the reading (device-wide scalar)
+    assert abs(marker_temperature_c(_d807_telemetry(28.94, channel=0)) - 28.94) < 1e-3
+    # non-telemetry payloads yield None
+    assert marker_temperature_c(_d807_delimiter(b'\xce\x57', channel=2)) is None
+    assert marker_temperature_c(bytes([0xeb, 0x07, 0, 0]) + bytes(40)) is None
+    assert marker_temperature_c(bytes([0xd8, 0x07])) is None        # truncated
+
+
+def test_is_run_delimiter_distinguishes_subforms():
+    # The delimiter sub-form ends a run; the telemetry sub-form does not.
+    assert is_run_delimiter(_d807_delimiter(b'\xce\x57', channel=2)) is True
+    assert is_run_delimiter(_d807_telemetry(15.5, channel=1)) is False
+    # an unrecognised/bare d807 still flushes (conservative); eb07 never does
+    assert is_run_delimiter(bytes([0xd8, 0x07])) is True
+    assert is_run_delimiter(bytes([0xeb, 0x07, 0, 0]) + bytes(40)) is False
+
+
+def test_assembler_keeps_ping_whole_across_telemetry_marker():
+    # Regression for issue #37: a 020c temperature marker interleaved mid-run
+    # must NOT split the ping. Build one channel's run as 4 packets + a telemetry
+    # marker + 3 more packets, then a delimiter; expect ONE scan line of all 7.
+    assembler = PingAssembler()
+    pkt = bytes([0xeb, 0x07, 0, 0]) + bytes(8) + bytes([5]) + bytes(20) \
+        + bytes([174, 2, 172, 2]) + bytes([10, 20, 30])
+    out = []
+    for _ in range(4):
+        out += assembler.feed(pkt, recv_time=100.0)
+    out += assembler.feed(_d807_telemetry(15.5, channel=2))   # must not flush
+    for _ in range(3):
+        out += assembler.feed(pkt, recv_time=100.0)
+    out += assembler.feed(_d807_delimiter(b'\xce\x57', channel=5))  # real boundary
+    assert len(out) == 1                       # one whole ping, not two fragments
+    assert out[0].channel == 5
+    assert out[0].samples == bytes([10, 20, 30]) * 7
 
 
 def test_d807_marker_tags_an_adjacent_run_channel():

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -15,6 +15,7 @@ from garmin_sidescan.node import (
     GEN_VOTE_MIN,
     imagery_diag_level,
     range_in_bounds,
+    temperature_plausible,
     temperature_publish_due,
     transmit_state_after,
     watchdog_action,
@@ -27,6 +28,15 @@ def test_imagery_diag_level():
     assert imagery_diag_level(True, None)[0] == err      # transmitting, never received
     assert imagery_diag_level(True, 10.0)[0] == err      # transmitting, stale
     assert imagery_diag_level(True, 0.5)[0] == ok        # transmitting, fresh
+
+
+def test_temperature_plausible():
+    assert temperature_plausible(15.5) is True
+    assert temperature_plausible(28.9) is True
+    assert temperature_plausible(-5.0) is True       # boundary inclusive
+    assert temperature_plausible(50.0) is True
+    assert temperature_plausible(-40.0) is False      # corrupt-frame garbage
+    assert temperature_plausible(1e6) is False
 
 
 def test_temperature_publish_due():

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -15,6 +15,7 @@ from garmin_sidescan.node import (
     GEN_VOTE_MIN,
     imagery_diag_level,
     range_in_bounds,
+    temperature_publish_due,
     transmit_state_after,
     watchdog_action,
 )
@@ -26,6 +27,18 @@ def test_imagery_diag_level():
     assert imagery_diag_level(True, None)[0] == err      # transmitting, never received
     assert imagery_diag_level(True, 10.0)[0] == err      # transmitting, stale
     assert imagery_diag_level(True, 0.5)[0] == ok        # transmitting, fresh
+
+
+def test_temperature_publish_due():
+    # first reading always publishes
+    assert temperature_publish_due(15.5, None, 0.0) is True
+    # a triplet of identical values collapses to one (the repeats are suppressed)
+    assert temperature_publish_due(15.5, 15.5, 0.01) is False
+    # a changed value publishes immediately
+    assert temperature_publish_due(15.6, 15.5, 0.01) is True
+    # a steady value heartbeats after the interval
+    assert temperature_publish_due(15.5, 15.5, 2.5) is True
+    assert temperature_publish_due(15.5, 15.5, 2.0) is True   # boundary inclusive
 
 
 def test_successful_on_is_transmitting():


### PR DESCRIPTION
Closes #37

## Problem

The GCV sidescan driver otherwise worked well on the 2026-06-12 pier bags, but ~80–140 pings per channel per hour came out **split into two messages** — visible as doubled/half-width columns. Root cause: `PingAssembler` flushed a scan-line run on **any** `d807` datagram, but the GCV emits two `d807` sub-forms:

| sub-form | payload | role |
|---|---|---|
| delimiter | `02 ǀ 0x10\|L v1 ǀ 19 ch` | ends a channel run (real boundary) |
| telemetry | `02 0c <float32 LE> 19 ch` | water temperature, interleaved **mid-run** (per-channel triplet ~0.7 Hz) |

Flushing on the telemetry frame tore the down-look ping in two.

## Fix

1. **Assembler** flushes only on the delimiter sub-form (`is_run_delimiter`); the telemetry frame no longer ends a run. A dropped delimiter is still backstopped by the next channel's first packet.
2. **Decode + publish** the telemetry float32 as **water temperature** on `~/water_temperature` (`sensor_msgs/Temperature`), one reading per triplet with a 2 s heartbeat.
3. **Docs**: `gcv_protocol.md` §3.C / §6 — resolves the open question on the `020c` value.

## What the `020c` value is

A float32 **water temperature (°C)**, validated each within one water body / day:
- 2026-06-10 pier: `020c` 15.5 °C vs an AML CTD cast surface 16.0–16.5 °C (≤1 °C).
- 2026-06-12: the value predicts the boat's own SVS sound speed within 1–3 m/s.

It reads the warm surface skin the hull transducer sits in (CTD profiles confirm surface stratification).

## Validation

Re-decoding `bag_2026-06-12T16.06.52` with the fix drops short pings from **140/82/122 → 2/0/0** per channel (the residual 2 are genuine UDP loss — no data lost, the split fragments summed to whole pings). 7,692 temperatures decode at 25.2–29.0 °C. Retroactive: re-decoding existing bags re-joins the fragments.

## Tests

73 pass (flake8 + ament_pep257 + pytest). New: telemetry-mid-run assembles one whole ping; real-capture-frame decode (pins byte layout); non-finite rejection; truncated-frame flush; sub-form discrimination; `temperature_plausible` / `temperature_publish_due`.

## Pre-push review

A fresh-context adversarial pass found one must-fix (corrupt frame → NaN published, and NaN defeats change-detection) and two suggestions (truncated `020c` swallowed; overstated backstop comment) — all addressed in this branch (see `.agent/work-plans/issue-37/progress.md`). Copilot Adversarial was skipped (monthly quota exceeded).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
