### PR TITLE
garmin_sidescan: adopt marine_control for transmit + range

### DIFF
--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -27,10 +27,12 @@ import time
 
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 from marine_acoustic_msgs.msg import RawSonarImage, SonarImageData
+from marine_control_py import ControlServer
 from marine_radar_control_msgs.msg import RadarControlItem, RadarControlSet, RadarControlValue
-from rcl_interfaces.msg import SetParametersResult
+from rcl_interfaces.msg import FloatingPointRange, ParameterDescriptor, SetParametersResult
 import rclpy
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from rosidl_runtime_py.utilities import get_message
 from sensor_msgs.msg import Range, Temperature
@@ -237,11 +239,31 @@ class GarminSidescanNode(Node):
         # transmit / safety
         self.declare_parameter('transmit_on_startup', False)
         self.declare_parameter('startup_off_repeats', 3)
-        self.declare_parameter('range_m', 0.0)
 
-        # operator control set (radar-style; rendered by CAMP)
+        # operator control set (radar-style; rendered by CAMP). Declare the range
+        # bounds first so range_m can carry a FloatingPointRange descriptor built
+        # from them for the marine_control panel.
         self.declare_parameter('range_min_m', 1.0)
         self.declare_parameter('range_max_m', 60.0)
+        # range_m default 0.0 = "do not command a range at startup". The
+        # descriptor upper bound is range_max_m; the lower bound stays 0.0 so the
+        # default is valid (sub-range_min_m values are rejected by _on_param_set,
+        # which enforces range_min_m). step 0.0 = continuous.
+        range_max = float(self.get_parameter('range_max_m').value)
+        self.declare_parameter(
+            'range_m', 0.0,
+            ParameterDescriptor(
+                description=('Sonar display range in metres (0 = leave the device '
+                             'default at startup; effective minimum is range_min_m).'),
+                floating_point_range=[
+                    FloatingPointRange(from_value=0.0, to_value=range_max, step=0.0)]))
+        # transmit on/off as a bridgeable marine_control. Holds ACTUAL transmit
+        # state, reconciled by the watchdog so the operator panel never lies.
+        self.declare_parameter(
+            'transmit', False,
+            ParameterDescriptor(
+                description=('Sonar transmit on/off (safety-guarded by the '
+                             'sound-speed watchdog).')))
         # TVG / interference frames are GCV-10-derived and unverified on the
         # GCV-20 (TVG is display-side there); expose them but allow opting out.
         self.declare_parameter('expose_gcv10_controls', True)
@@ -303,6 +325,10 @@ class GarminSidescanNode(Node):
         self._tx_lock = threading.Lock()      # guards transmit/latch state changes
         self._send_lock = threading.Lock()    # serializes TCP command sends
         self._transmitting = False
+        # True while _reconcile_transmit_param mirrors actual state into the
+        # `transmit` param, so _on_param_set skips re-issuing a transmit command.
+        self._tx_sync = False
+        self._control_server = None
         self._safety_latched = False
         self._last_valid_sv_t = None
         self._last_valid_sv_value = 0.0
@@ -402,6 +428,13 @@ class GarminSidescanNode(Node):
             self.get_logger().warn('sound_speed_topic empty: watchdog disabled')
 
         self.add_on_set_parameters_callback(self._on_param_set)
+
+        # marine_control device panel (bridgeable; rendered by rqt_marine_control).
+        # transmit + range for now; TVG/interference await enum support in the lib.
+        # Created before the timers so the watchdog can reconcile the transmit param.
+        self._control_server = ControlServer(self)
+        self._control_server.bind_parameter('transmit', group='sonar')
+        self._control_server.bind_parameter('range_m', units='m', group='sonar')
 
         self._rx_thread = threading.Thread(target=self._rx_loop, name='gcv_rx', daemon=True)
         self._rx_thread.start()
@@ -654,7 +687,35 @@ class GarminSidescanNode(Node):
         else:
             self._valid_streak = 0
 
+    def _reconcile_transmit_param(self):
+        """
+        Mirror actual transmit state into the `transmit` parameter.
+
+        Runs on the executor thread (the watchdog timer) so a watchdog- or
+        startup-thread-driven transmit change reaches the ControlServer echo
+        without a cross-thread set_parameters. The _tx_sync guard keeps
+        _on_param_set from re-issuing a transmit command for this mirror write.
+        """
+        if not self.has_parameter('transmit'):
+            return
+        # Snapshot under _tx_lock -- the startup daemon thread also mutates
+        # _transmitting -- for a consistent read, matching the file's discipline.
+        with self._tx_lock:
+            actual = self._transmitting
+        if bool(self.get_parameter('transmit').value) == actual:
+            return
+        self._tx_sync = True
+        try:
+            self.set_parameters([Parameter('transmit', Parameter.Type.BOOL, actual)])
+        finally:
+            self._tx_sync = False
+        if self._control_server is not None:
+            self._control_server.publish_state()
+
     def _watchdog(self):
+        # Reconcile first so an async transmit change (watchdog stop last tick,
+        # startup thread, auto-resume) is reflected in the panel promptly.
+        self._reconcile_transmit_param()
         age = self._sv_age()
         stop, kind = watchdog_action(
             safety_enabled=self._safety_enabled,
@@ -1010,6 +1071,7 @@ class GarminSidescanNode(Node):
         # because of a *different* param would desync the param store from the
         # hardware/UI. Side effects happen only once every param is acceptable.
         range_request = None
+        transmit_request = None
         for p in params:
             if p.name == 'range_m':
                 meters = float(p.value)
@@ -1027,6 +1089,8 @@ class GarminSidescanNode(Node):
                         reason=(f'range {meters} m invalid or outside '
                                 f'{self._range_min}-{self._range_max} m'))
                 range_request = meters
+            elif p.name == 'transmit':
+                transmit_request = bool(p.value)  # applied below (or mirror-only)
             elif p.name in ('sound_speed_safety_enabled', 'debug_raw'):
                 pass  # always acceptable; applied below
             elif p.name != 'use_sim_time' and self.has_parameter(p.name):
@@ -1055,6 +1119,19 @@ class GarminSidescanNode(Node):
             self._controls['range'] = f'{range_request:.1f}'
             self._publish_control_set()
             self.get_logger().info(f'range set to {range_request} m')
+
+        # Apply transmit last. ControlServer sets exactly one parameter per
+        # change, so transmit and range never share a batch from the operator
+        # path; applying it after range therefore can't break range's atomicity.
+        # Skip the command when this set is our own reconcile write (_tx_sync) --
+        # that only mirrors actual state into the param.
+        if transmit_request is not None and not self._tx_sync:
+            ok, reason = self._request_transmit(transmit_request)
+            if not ok:
+                # Refused (watchdog guard) or not achieved (a failed send can
+                # leave the sonar possibly still pinging): reject so the param
+                # stays at the actual transmit state, not the request.
+                return SetParametersResult(successful=False, reason=reason)
 
         for p in params:
             if p.name == 'sound_speed_safety_enabled':

--- a/garmin_sidescan/package.xml
+++ b/garmin_sidescan/package.xml
@@ -12,6 +12,7 @@
 
   <depend>rclpy</depend>
   <depend>marine_acoustic_msgs</depend>
+  <depend>marine_control_py</depend>
   <depend>marine_interfaces</depend>
   <depend>marine_radar_control_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -5,6 +5,7 @@ The critical invariant: a transmit-OFF command whose TCP send FAILED must not
 be recorded as OFF, or the watchdog would stop retrying and a dry transducer
 could keep pinging while everything reports OFF.
 """
+import threading
 import types
 
 from diagnostic_msgs.msg import DiagnosticStatus
@@ -150,7 +151,7 @@ class _FakeLogger:
 class _FakeNode:
     """Minimal stand-in exposing only the attributes _on_param_set touches."""
 
-    def __init__(self, send_ok=True, static_params=()):
+    def __init__(self, send_ok=True, static_params=(), tx_achieves=True):
         self._send_ok = send_ok
         self.sends = []
         self._static = set(static_params)
@@ -159,6 +160,12 @@ class _FakeNode:
         self._controls = {}
         self._safety_enabled = True
         self.publishes = 0
+        # transmit-control adoption
+        self._tx_sync = False
+        self._transmitting = False
+        self._tx_achieves = tx_achieves   # does _request_transmit reach the goal?
+        self._tx_force = None             # (ok, transmitting_after) override
+        self.transmit_requests = []
 
     def get_logger(self):
         return _FakeLogger()
@@ -172,6 +179,16 @@ class _FakeNode:
 
     def _publish_control_set(self):
         self.publishes += 1
+
+    def _request_transmit(self, on):
+        self.transmit_requests.append(on)
+        if self._tx_force is not None:
+            ok, self._transmitting = self._tx_force
+            return ok, 'forced'
+        if self._tx_achieves:
+            self._transmitting = on
+            return True, 'ok'
+        return False, 'refused'   # guard refused: actual state unchanged
 
 
 def _param(name, value):
@@ -219,6 +236,100 @@ def test_range_send_failure_rejects_without_mirroring():
     assert result.successful is False
     assert len(node.sends) == 1          # attempted
     assert 'range' not in node._controls  # but not mirrored on failure
+
+
+# ----- transmit-control adoption (marine_control) ------------------------
+
+def test_transmit_request_applied_when_achieved():
+    node = _FakeNode()
+    result = _on_param_set(node, [_param('transmit', True)])
+    assert result.successful is True
+    assert node.transmit_requests == [True]
+    assert node._transmitting is True
+
+
+def test_transmit_request_rejected_when_refused():
+    # The watchdog guard refuses ON: reject the set so the param stays at the
+    # actual (off) transmit state rather than falsely reporting on.
+    node = _FakeNode(tx_achieves=False)
+    result = _on_param_set(node, [_param('transmit', True)])
+    assert result.successful is False
+    assert node.transmit_requests == [True]
+    assert node._transmitting is False
+
+
+def test_transmit_off_applied_when_achieved():
+    node = _FakeNode()
+    node._transmitting = True
+    result = _on_param_set(node, [_param('transmit', False)])
+    assert result.successful is True
+    assert node.transmit_requests == [False]
+    assert node._transmitting is False
+
+
+def test_transmit_off_send_failure_rejected():
+    # Safety-critical branch: an OFF whose send failed leaves the sonar possibly
+    # still pinging (_transmitting stays True). _request_transmit returns ok=False
+    # there, so the set must be REJECTED -- the param must not claim 'off'.
+    node = _FakeNode()
+    node._transmitting = True
+    node._tx_force = (False, True)   # ok=False, still transmitting
+    result = _on_param_set(node, [_param('transmit', False)])
+    assert result.successful is False
+    assert node.transmit_requests == [False]
+    assert node._transmitting is True
+
+
+def test_transmit_sync_write_skips_command():
+    # A reconcile (mirror) write must NOT re-issue a transmit command.
+    node = _FakeNode()
+    node._tx_sync = True
+    result = _on_param_set(node, [_param('transmit', True)])
+    assert result.successful is True
+    assert node.transmit_requests == []
+
+
+class _FakeReconcileNode:
+    """Stand-in exposing only what _reconcile_transmit_param touches."""
+
+    def __init__(self, param_value, transmitting):
+        self._params = {'transmit': types.SimpleNamespace(value=param_value)}
+        self._transmitting = transmitting
+        self._tx_sync = False
+        self._tx_lock = threading.Lock()
+        self.set_calls = []
+        self.published = False
+        self._control_server = types.SimpleNamespace(
+            publish_state=lambda: setattr(self, 'published', True))
+
+    def has_parameter(self, name):
+        return name in self._params
+
+    def get_parameter(self, name):
+        return self._params[name]
+
+    def set_parameters(self, params):
+        for p in params:
+            self.set_calls.append((p.name, p.value))
+            # the guard must be set while the write happens
+            assert self._tx_sync is True
+            self._params[p.name] = types.SimpleNamespace(value=p.value)
+        return [types.SimpleNamespace(successful=True)]
+
+
+def test_reconcile_writes_param_when_out_of_sync():
+    node = _FakeReconcileNode(param_value=False, transmitting=True)
+    GarminSidescanNode._reconcile_transmit_param(node)
+    assert node.set_calls == [('transmit', True)]
+    assert node._tx_sync is False        # guard reset after the write
+    assert node.published is True         # panel refreshed promptly
+
+
+def test_reconcile_noop_when_in_sync():
+    node = _FakeReconcileNode(param_value=True, transmitting=True)
+    GarminSidescanNode._reconcile_transmit_param(node)
+    assert node.set_calls == []
+    assert node.published is False
 
 
 # ----- device auto-detect from render-layer structure --------------------


### PR DESCRIPTION
## `garmin_sidescan`: adopt marine_control for transmit + range

Closes #39. First sensor adopter of the marine_control device library (ADR-0003 D8.1, `unh_marine_autonomy#140`).

The driver's operator controls were a borrowed `marine_radar_control_msgs/RadarControlSet` on `~/state`/`~/change_state` that was **never bridged** to the operator station — the `unh_marine_autonomy#250` gap. This exposes **transmit + range** over the generic, bridgeable `marine_control_interfaces` contract via `marine_control_py.ControlServer`, which `rqt_marine_control` already renders.

### Changes
- **transmit** — new `bool` parameter; on-set callback routes to the existing safety-guarded `_request_transmit`, accepting only if the requested state was actually achieved (else reject, so the param never claims a state the sonar isn't in). A failed-OFF (sonar possibly still pinging) is rejected.
- **range_m** — given a `FloatingPointRange(0..range_max_m, step=0.0)` descriptor so the panel shows bounds; rclpy enforces the upper bound, `_on_param_set` still enforces `range_min_m`. Bounds declared before `range_m`.
- **`_reconcile_transmit_param`** — mirrors *actual* transmit state into the `transmit` param each watchdog tick (executor thread), guarded by `_tx_sync` so it never re-issues a command. The watchdog can stop transmit asynchronously; this keeps the operator panel honest without a cross-thread `set_parameters`.

### Safety
The dry-transducer invariant is unchanged: the transmit-as-parameter path is a thin wrapper over the existing `_guard_transmit_on`; the reconcile/mirror write can never start transmit; the watchdog acts on `_transmitting`/hardware directly, never via the param round-trip (panel lag ≤1 s is cosmetic only).

### Review
Two **Deep adversarial passes** (logic + safety/concurrency): **no must-fix defects** — the guard is preserved and reconcile can't energize the transducer. Applied suggestions: use `_request_transmit`'s verdict, snapshot `_transmitting` under `_tx_lock` in reconcile, document the single-param atomicity assumption, and add **OFF / failed-OFF safety-branch tests**. 80 tests pass; flake8 + pep257 green.

### Scope / follow-ups
- Interim: the `RadarControlSet` surface stays (unbridged, dead topside) so TVG/interference remain until they migrate (await enum support in the lib).
- **`bizzyboat.yaml` bridge wiring** (separate PR in the platform repo) — bridge `control/state` boat→op and `control/change` op→boat; closes the `#250` gap.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
