### PR TITLE
garmin_sidescan: remove sound-speed interlock + fix near-field blanking (sample0)

### DIFF
--- a/.agent/work-plans/issue-41/progress.md
+++ b/.agent/work-plans/issue-41/progress.md
@@ -16,10 +16,17 @@ issue: 41
 **Must-fix**: 2 | **Suggestions**: 5
 
 ### Findings
-- [ ] (must-fix) Dry-transducer auto-stop premise is asserted (README/docstring/commit) but cited nowhere authoritative; gcv_protocol.md has no out-of-water/auto-stop note — record provenance (Roland's field knowledge) + ideally bench-confirm — `garmin_sidescan/README.md:103`
-- [ ] (must-fix) transmit_on_startup now does an unconditional transmit ON (startup SV guard removed), so an out-of-water power-up with transmit_on_startup:=true commands a dry transmit with no in-driver protection — `garmin_sidescan/garmin_sidescan/node.py:418`
-- [ ] (suggestion) sample0 becoming nonzero is a breaking RawSonarImage wire-contract change; out-of-repo consumers (rqt_marine_sonar/rqt_operator_tools waterfall, CAMP) that assumed sample0==0 must be audited — `garmin_sidescan/garmin_sidescan/node.py:825`
-- [ ] (suggestion) ping_info.sound_speed changed from best-available measurement (0.0 when stale) to a fixed nominal 1500; note the semantic shift for consumers — `garmin_sidescan/garmin_sidescan/node.py:796`
-- [ ] (suggestion) transmit diagnostic dropped the "maybe-dry-transmitting" WARN; with the interlock gone this removes the one operational signal for a possibly-dry transmit — `garmin_sidescan/garmin_sidescan/node.py:855`
+- [x] (must-fix) Dry-transducer auto-stop premise cited nowhere → **resolved (docs)**: provenance (R. Arsenault field obs) + bench-confirm TODO recorded in gcv_protocol.md §4.6; README states it's unconfirmed. Bench-confirm stays a tracked TODO in the protocol doc — `garmin_sidescan/docs/gcv_protocol.md`
+- [x] (must-fix) transmit_on_startup unconditional ON → **resolved (docs)**: README + param table warn that startup/commanded transmit is unguarded; only energize submerged. (User decision: keep interlock removed, document the operational constraint.) — `garmin_sidescan/README.md`
+- [x] (suggestion) sample0 nonzero is a breaking RawSonarImage wire-contract change → **tracked as rolker/marine_tools#42** (audit rqt waterfall / CAMP); called out in the PR body
+- [ ] (suggestion) ping_info.sound_speed changed from measurement (0.0 when stale) to fixed nominal 1500; semantic shift documented in README + PR body — `garmin_sidescan/garmin_sidescan/node.py:796`
+- [ ] (suggestion) transmit diagnostic dropped the "maybe-dry-transmitting" WARN; accepted as a consequence of the interlock removal — `garmin_sidescan/garmin_sidescan/node.py:855`
 - [x] (suggestion) bins>GRID_BINS warning understated the consequence (scale wrong for over-length tail) — reworded — `garmin_sidescan/garmin_sidescan/node.py:813`
 - [x] (suggestion) parse_subheader docstring said bin size = display_range/n_bins; corrected to /GRID_BINS — `garmin_sidescan/garmin_sidescan/decode.py:410`
+
+### Resolution (pre-push, before push)
+Two doc commits address the review: `5c59036` records the auto-stop premise
+provenance + transmit_on_startup caveat and the two Lens A doc nits. Remaining
+open items are intentional consequences (sound_speed nominal, dropped WARN) or
+tracked separately (#42). Bench-confirm of the auto-stop latency stays a TODO in
+gcv_protocol.md §4.6. Cleared to push + open PR.

--- a/.agent/work-plans/issue-41/progress.md
+++ b/.agent/work-plans/issue-41/progress.md
@@ -1,0 +1,25 @@
+---
+issue: 41
+---
+
+# Issue #41 — garmin_sidescan: remove sound-speed interlock + fix near-field blanking (sample0) in range encoding
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 01:25 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-41 at `1d0f774`
+**Mode**: pre-push
+**Depth**: Standard (reason: sensor-driver node, transmit-control + message-contract change, 207+/363- across 11 files)
+**Must-fix**: 2 | **Suggestions**: 5
+
+### Findings
+- [ ] (must-fix) Dry-transducer auto-stop premise is asserted (README/docstring/commit) but cited nowhere authoritative; gcv_protocol.md has no out-of-water/auto-stop note — record provenance (Roland's field knowledge) + ideally bench-confirm — `garmin_sidescan/README.md:103`
+- [ ] (must-fix) transmit_on_startup now does an unconditional transmit ON (startup SV guard removed), so an out-of-water power-up with transmit_on_startup:=true commands a dry transmit with no in-driver protection — `garmin_sidescan/garmin_sidescan/node.py:418`
+- [ ] (suggestion) sample0 becoming nonzero is a breaking RawSonarImage wire-contract change; out-of-repo consumers (rqt_marine_sonar/rqt_operator_tools waterfall, CAMP) that assumed sample0==0 must be audited — `garmin_sidescan/garmin_sidescan/node.py:825`
+- [ ] (suggestion) ping_info.sound_speed changed from best-available measurement (0.0 when stale) to a fixed nominal 1500; note the semantic shift for consumers — `garmin_sidescan/garmin_sidescan/node.py:796`
+- [ ] (suggestion) transmit diagnostic dropped the "maybe-dry-transmitting" WARN; with the interlock gone this removes the one operational signal for a possibly-dry transmit — `garmin_sidescan/garmin_sidescan/node.py:855`
+- [x] (suggestion) bins>GRID_BINS warning understated the consequence (scale wrong for over-length tail) — reworded — `garmin_sidescan/garmin_sidescan/node.py:813`
+- [x] (suggestion) parse_subheader docstring said bin size = display_range/n_bins; corrected to /GRID_BINS — `garmin_sidescan/garmin_sidescan/decode.py:410`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,22 +41,26 @@ jobs:
       - name: Create workspace
         run: mkdir -p ../ws/src && ln -s "$GITHUB_WORKSPACE" ../ws/src/marine_tools
 
-      # marine_tools packages depend on three interface packages that are source
-      # siblings, not rosdep/binary packages: marine_interfaces
-      # (unh_marine_autonomy), udp_bridge_interfaces (udp_bridge), and
-      # marine_radar_control_msgs (unh_marine_radar — used by garmin_sidescan).
-      # Clone each and prune to just the interface package so rosdep/colcon stay
-      # light (the parent repos carry heavy nav2/mavros/radar packages we don't
-      # need). The workspace `make build` is the full integration gate; this
+      # marine_tools packages depend on source-sibling packages that are not
+      # rosdep/binary packages: marine_interfaces (unh_marine_autonomy),
+      # udp_bridge_interfaces (udp_bridge), marine_radar_control_msgs
+      # (unh_marine_radar), and marine_control_py + marine_control_interfaces
+      # (marine_control — garmin_sidescan's ControlServer, added in #39). Clone
+      # each parent repo and prune to just the package(s) we need so rosdep/colcon
+      # stay light (the parent repos carry heavy nav2/mavros/radar/Qt packages we
+      # don't need). The workspace `make build` is the full integration gate; this
       # per-repo CI is the lighter-weight check.
       - name: Clone source-sibling interface packages
         run: |
           set -e
-          clone_prune() {  # <repo-url> <branch> <dir> <keep-package-dir>
-            git clone --depth 1 -b "$2" "$1" "../ws/src/$3"
-            ( cd "../ws/src/$3" && \
+          clone_prune() {  # <repo-url> <branch> <dir> <keep-package-dir>...
+            local url="$1" branch="$2" dir="$3"; shift 3
+            git clone --depth 1 -b "$branch" "$url" "../ws/src/$dir"
+            local prune=() keep
+            for keep in "$@"; do prune+=( ! -name "$keep" ); done
+            ( cd "../ws/src/$dir" && \
               find . -maxdepth 1 -mindepth 1 -type d \
-                ! -name "$4" ! -name '.git' -exec rm -rf {} + )
+                "${prune[@]}" ! -name '.git' -exec rm -rf {} + )
           }
           clone_prune https://github.com/rolker/unh_marine_autonomy.git jazzy \
             unh_marine_autonomy marine_interfaces
@@ -64,6 +68,8 @@ jobs:
             udp_bridge udp_bridge_interfaces
           clone_prune https://github.com/rolker/unh_marine_radar.git jazzy \
             unh_marine_radar marine_radar_control_msgs
+          clone_prune https://github.com/rolker/marine_control.git jazzy \
+            marine_control marine_control_py marine_control_interfaces
 
       - name: Install ROS dependencies
         working-directory: ../ws

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,16 @@ jobs:
       - name: Clone source-sibling interface packages
         run: |
           set -e
+          # POSIX sh (this step runs under dash, no bash arrays): build the
+          # find prune expression as a string and eval it. Keep-names are
+          # workflow-controlled literals, so the eval is safe.
           clone_prune() {  # <repo-url> <branch> <dir> <keep-package-dir>...
-            local url="$1" branch="$2" dir="$3"; shift 3
+            url="$1"; branch="$2"; dir="$3"; shift 3
             git clone --depth 1 -b "$branch" "$url" "../ws/src/$dir"
-            local prune=() keep
-            for keep in "$@"; do prune+=( ! -name "$keep" ); done
+            prune=""
+            for keep in "$@"; do prune="$prune ! -name '$keep'"; done
             ( cd "../ws/src/$dir" && \
-              find . -maxdepth 1 -mindepth 1 -type d \
-                "${prune[@]}" ! -name '.git' -exec rm -rf {} + )
+              eval "find . -maxdepth 1 -mindepth 1 -type d $prune ! -name '.git' -exec rm -rf {} +" )
           }
           clone_prune https://github.com/rolker/unh_marine_autonomy.git jazzy \
             unh_marine_autonomy marine_interfaces

--- a/garmin_sidescan/README.md
+++ b/garmin_sidescan/README.md
@@ -1,9 +1,9 @@
 # garmin_sidescan
 
 ROS 2 driver for the Garmin GCV-10 / GCV-20 sidescan sonar (Marine Network).
-Decodes the imagery multicast into `marine_acoustic_msgs/RawSonarImage`, owns
-transmit/range control over the GCV TCP command port, and interlocks transmit
-on a sound-speed watchdog so a dry transducer cannot overheat.
+Decodes the imagery multicast into `marine_acoustic_msgs/RawSonarImage` and owns
+transmit/range control over the GCV TCP command port. (The GCV stops pinging on
+its own when out of the water, so no external sound-speed interlock is needed.)
 
 The chartplotter is required only to power up / wake the Marine Network; it is
 otherwise inaccessible, so **this node performs all sonar control.**
@@ -87,28 +87,21 @@ dynamically: the node publishes a `RadarControlSet` on `state` and accepts
 
 | Control | Type | Values | Notes |
 |---------|------|--------|-------|
-| `status` | enum | `standby` / `transmit` | routed through the safety guard; reflects watchdog-driven changes |
+| `status` | enum | `standby` / `transmit` | reflects actual transmit state |
 | `range` | float | `range_min_m`..`range_max_m` (m) | verified on GCV-20 |
 | `tvg` | enum | `off`/`low`/`medium`/`high` | GCV-10-derived; **unverified on GCV-20** (TVG is display-side there) |
 | `interference` | enum | `off`/`low`/`medium`/`high` | GCV-10-derived; **unverified on GCV-20** |
 
 `tvg` / `interference` are gated by `expose_gcv10_controls` (default true).
-`status=transmit` cannot bypass the sound-speed interlock — it goes through the
-same guard as the service.
 
-## Safety
+## Transmit safety
 
 - **Transmit OFF at startup** — the node asserts off and never pings without an
   explicit command (pairs with the chartplotter defaulting to not pinging on
   power-up).
-- **Sound-speed watchdog** — while transmitting, if sound speed reads NaN / 0 /
-  outside `sv_min`–`sv_max` (plausible in-water range) for `sv_timeout`
-  seconds, transmit auto-stops. Auto-resumes when a valid in-water sound speed
-  returns (`auto_resume`, default on); a manual off is never auto-overridden.
-- **`sound_speed_safety_enabled`** — dynamic master switch (default enabled).
-  Toggle live for out-of-water bench testing:
-  `ros2 param set <node> sound_speed_safety_enabled false`.
 - Transmit-off is also sent on node shutdown.
+- No external sound-speed interlock is needed: the GCV stops pinging on its own
+  when out of the water, so a dry transducer cannot overheat.
 
 ## Protocol notes
 
@@ -137,11 +130,7 @@ imagery stream because they are not reliably present there:
 | `nadir_frame_id` | `''` | frame for `nadir_depth` (+X down); empty derives `<frame_id>_nadir` |
 | `nadir_beam_width_rad` | `0.0` | `Range.field_of_view` for `nadir_depth` |
 | `transmit_on_startup` | `false` | safe default |
-| `sound_speed_safety_enabled` | `true` | dynamic master switch |
-| `require_sound_speed` | `true` | refuse transmit unless a valid SV is fresh; `false` for bench tests |
-| `sv_min` / `sv_max` | `1400` / `1600` | plausible in-water sound speed (m/s) |
-| `sv_timeout` | `12.0` | seconds of bad/missing SV before auto-stop |
-| `auto_resume` | `true` | resume transmit when valid in-water SV returns |
+| `sound_speed` | `1500.0` | device's assumed sound speed (m/s) used to build the `sample_rate` scale and stamped into `ping_info.sound_speed`; see Protocol notes |
 | `range_m` | `0.0` | >0 commands range (settable at runtime) |
 | `range_min_m` / `range_max_m` | `1.0` / `60.0` | bounds of the range control |
 | `expose_gcv10_controls` | `true` | include TVG / interference controls |

--- a/garmin_sidescan/README.md
+++ b/garmin_sidescan/README.md
@@ -100,8 +100,13 @@ dynamically: the node publishes a `RadarControlSet` on `state` and accepts
   explicit command (pairs with the chartplotter defaulting to not pinging on
   power-up).
 - Transmit-off is also sent on node shutdown.
-- No external sound-speed interlock is needed: the GCV stops pinging on its own
-  when out of the water, so a dry transducer cannot overheat.
+- **No external sound-speed interlock.** The GCV stops pinging on its own when
+  out of the water, so a dry transducer cannot overheat — the driver relies on
+  that rather than a watchdog. This rests on a field observation (the unit stops
+  pinging in air); it is **not yet** confirmed against a Garmin spec or a
+  recorded bench test (see `docs/gcv_protocol.md` §4.6). **Until it is, do not
+  set `transmit_on_startup:=true` or command transmit with the transducer in
+  air** — startup/commanded transmit is unguarded.
 
 ## Protocol notes
 
@@ -154,7 +159,7 @@ correction must match this parameter, or it double-corrects the range.
 | `sample_rate_hz` | `0.0` | last-resort fallback when neither the sub-header v2 nor a commanded range gives a scale; 0 = unavailable |
 | `nadir_frame_id` | `''` | frame for `nadir_depth` (+X down); empty derives `<frame_id>_nadir` |
 | `nadir_beam_width_rad` | `0.0` | `Range.field_of_view` for `nadir_depth` |
-| `transmit_on_startup` | `false` | safe default |
+| `transmit_on_startup` | `false` | safe default; only enable with the transducer **submerged** — startup transmit is unguarded (see Transmit safety) |
 | `sound_speed` | `1500.0` | device's assumed sound speed (m/s) used to build the `sample_rate` scale and stamped into `ping_info.sound_speed`; see Protocol notes |
 | `range_m` | `0.0` | >0 commands range (settable at runtime) |
 | `range_min_m` / `range_max_m` | `1.0` / `60.0` | bounds of the range control |

--- a/garmin_sidescan/README.md
+++ b/garmin_sidescan/README.md
@@ -118,6 +118,31 @@ imagery stream because they are not reliably present there:
   is stamped with the ROS receive time of its first packet. On an NTP-synced
   host this is accurate to a few ms; note it is receive (not transmit) time.
 
+### Range scale, near-field gate, and `sound_speed`
+
+The GCV reports a per-ping **display range** (sub-header v2) and frames every
+ping as a fixed **2048-sample line** spanning `[0, display_range]`, delivering
+only the **last `n_bins`** of that grid — the first `2048 − n_bins` samples are
+a gated near-field zone (~0.1 m). The driver encodes this as:
+
+- `sample_rate = sound_speed · 2048 / (2 · display_range)` — derived from the
+  full grid, and
+- `sample0 = 2048 − n_bins` — the omitted near-field head.
+
+A consumer recovers delivered sample `j` at
+`range = sound_speed · (sample0 + j) / (2 · sample_rate)`, so the data starts at
+the near-field offset, not at range 0. (Encoding `sample0 = 0` mis-scales every
+sample — ~20 % of range at short range.) The 2048 grid is validated on the
+GCV-20: the down-look bottom echo lands at the reported `bottom_range_m` only
+under this geometry.
+
+`sound_speed` here is the **device's assumed** sound speed (parameter, default
+1500 m/s), used to build the scale and stamped into `ping_info.sound_speed`. The
+GCV reports range in metres already, so any consistent value round-trips the
+geometry; it does **not** track water temperature/salinity (the device exposes
+no such setting). A downstream consumer that re-applies its own sound-speed
+correction must match this parameter, or it double-corrects the range.
+
 ## Key parameters
 
 | Parameter | Default | Notes |

--- a/garmin_sidescan/docs/gcv_protocol.md
+++ b/garmin_sidescan/docs/gcv_protocol.md
@@ -400,6 +400,16 @@ The driver's control path (from `commands.py`; envelope in §1). Builders:
 force-manual-range builder — needed only to hold a fixed swath against the
 chartplotter's auto-range.
 
+**Transmit safety — out-of-water auto-stop (issue #41).** The driver does not
+gate transmit on an external sound-speed reading; it relies on the GCV ceasing
+to ping on its own when the transducer is out of the water, so a dry transducer
+cannot overheat. **Source: field observation (R. Arsenault) — the unit stops
+pinging in air.** This is **not yet** independently confirmed against a Garmin
+spec or a recorded bench test. **TODO: bench-confirm the dry → transmit-stop
+latency and cite it here.** Until then, treat `transmit_on_startup` and any
+commanded transmit as unprotected against a dry transducer — only energize with
+the transducer submerged.
+
 ### 4.7 Chartplotter-side streams (bench inventory; not consumed by the driver)
 
 The 06-05 bucket captures show the chartplotter (`172.16.6.64`) broadcasting

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -452,10 +452,25 @@ def parse_downlook_subheader(payload):
     return parse_subheader(payload)
 
 
-def derive_sample_rate(sub, n_bins, sound_speed, commanded_range_m=0.0,
+# The GCV frames every ping as a fixed-length line of GRID_BINS samples spanning
+# [0, display_range], independent of range; the near-field is gated by delivering
+# only the *last* n_bins of that grid (the first GRID_BINS - n_bins samples are
+# omitted). So sample_rate is derived from the full grid and the omitted count is
+# the RawSonarImage sample0 -- see GarminSidescanNode._make_sonar_msg. 2^11,
+# validated on the GCV-20 (the down-look bottom echo lands at the reported
+# bottom_range_m only under this geometry) and consistent with the GCV-10 ceiling.
+GRID_BINS = 2048
+
+
+def derive_sample_rate(sub, grid_bins, sound_speed, commanded_range_m=0.0,
                        fallback_rate=0.0):
     """
     Return the ``RawSonarImage.sample_rate`` (Hz) for one assembled ping.
+
+    ``grid_bins`` is the device's full per-ping line length (:data:`GRID_BINS`),
+    spanning ``[0, display_range]`` -- NOT the delivered sample count, which is
+    the gated tail of that grid (the near-field offset is carried by
+    ``sample0``; see :meth:`GarminSidescanNode._make_sonar_msg`).
 
     The scale source, in priority order:
 
@@ -469,14 +484,15 @@ def derive_sample_rate(sub, n_bins, sound_speed, commanded_range_m=0.0,
     3. **``fallback_rate``** -- a manually configured rate, or 0.0 =
        "unavailable" (the ``RawSonarImage`` convention).
 
-    With a range ``R`` the rate is ``sound_speed * n_bins / (2 * R)``, so a
-    consumer recovers ``R = sound_speed * n_bins / (2 * rate)``.
+    With a range ``R`` over the full grid the rate is
+    ``sound_speed * grid_bins / (2 * R)``, so a consumer recovers a delivered
+    sample ``j`` at ``range = sound_speed * (sample0 + j) / (2 * rate)``.
     """
     range_m = sub.display_range_m if sub is not None else 0.0
     if range_m <= 0.0:
         range_m = commanded_range_m
-    if range_m > 0.0 and sound_speed > 0.0 and n_bins > 0:
-        return sound_speed * n_bins / (2.0 * range_m)
+    if range_m > 0.0 and sound_speed > 0.0 and grid_bins > 0:
+        return sound_speed * grid_bins / (2.0 * range_m)
     return fallback_rate
 
 

--- a/garmin_sidescan/garmin_sidescan/decode.py
+++ b/garmin_sidescan/garmin_sidescan/decode.py
@@ -407,9 +407,10 @@ def parse_subheader(payload):
     lengths, so a garbled payload yields None. Returns a :class:`Subheader`:
     ``display_range_m`` (v2) is this channel's own scan extent -- water-column
     depth range on the down-look, across-track slant range on the side-scan --
-    so bin size = ``display_range_m / n_bins`` must use the matching channel;
-    ``bottom_range_m`` (v1) is the shared bottom range; ``v1_tag`` is field2's
-    raw tag byte (``0x10 | len(v1)``, the ex-"range bracket").
+    so bin size = ``display_range_m / GRID_BINS`` must use the matching channel
+    (see :func:`derive_sample_rate`); ``bottom_range_m`` (v1) is the shared
+    bottom range; ``v1_tag`` is field2's raw tag byte (``0x10 | len(v1)``, the
+    ex-"range bracket").
     """
     if (payload[:2] != EB07 or len(payload) < 33
             or payload[9:12] != b'\x01\x03\x09'):

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -811,9 +811,14 @@ class GarminSidescanNode(Node):
         # better "unavailable" than wrong.
         bins = len(samples) // self._bytes_per_sample
         if bins > GRID_BINS:
+            # The device is not expected to exceed the fixed grid; if it does,
+            # the grid model is violated and the scale below is wrong for the
+            # over-length tail (sample0 floors at 0 via max()). Loud + throttled
+            # rather than silently publishing a confidently-wrong scale.
             self.get_logger().warn(
-                f'ping has {bins} bins > GRID_BINS ({GRID_BINS}); near-field '
-                'gate (sample0) clamped to 0', throttle_duration_sec=30.0)
+                f'ping has {bins} bins > GRID_BINS ({GRID_BINS}); fixed-grid '
+                'scale assumption violated, published scale is unreliable',
+                throttle_duration_sec=30.0)
         commanded = (0.0 if side == 'down'
                      else float(self._controls.get('range') or 0.0))
         msg.sample_rate = derive_sample_rate(

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -46,8 +46,8 @@ from .commands import (
 )
 from .decode import (
     CHANNEL_OFFSET, dark_layer, derive_sample_rate, EB07, echo_layer,
-    generation_from_layers, is_water_column, marker_temperature_c, MIN_DATA_LEN,
-    PingAssembler, status_transmitting)
+    generation_from_layers, GRID_BINS, is_water_column, marker_temperature_c,
+    MIN_DATA_LEN, PingAssembler, status_transmitting)
 
 # Auxiliary GCV multicast streams the driver can listen to. The imagery group
 # is a parameter (mcast_group/port); these two are fixed by the GCV protocol.
@@ -795,7 +795,13 @@ class GarminSidescanNode(Node):
         msg.ping_info.frequency = self._freq[side]
         sv = self._sound_speed
         msg.ping_info.sound_speed = sv
-        # Derive sample_rate so a consumer recovers range = sv*bins/(2*rate).
+        # The GCV frames each ping as a fixed GRID_BINS-sample line spanning
+        # [0, display_range] and gates the near-field by delivering only the
+        # LAST `bins` of that grid. So derive sample_rate from the full grid and
+        # expose the omitted head count as sample0: a consumer then recovers a
+        # delivered sample j at range = sv*(sample0 + j)/(2*rate), i.e. the data
+        # starts at the near-field offset, not at range 0. (Publishing sample0=0
+        # mis-scales every sample, by ~20% of range at short range.)
         # The range source is the ping's OWN sub-header v2 (per channel, tracks
         # hardware auto-range), falling back to the commanded-range mirror and
         # then the sample_rate_hz parameter -- see decode.derive_sample_rate.
@@ -804,13 +810,19 @@ class GarminSidescanNode(Node):
         # swath, so a wrong-but-confident ~2x scale must not be published --
         # better "unavailable" than wrong.
         bins = len(samples) // self._bytes_per_sample
+        if bins > GRID_BINS:
+            self.get_logger().warn(
+                f'ping has {bins} bins > GRID_BINS ({GRID_BINS}); near-field '
+                'gate (sample0) clamped to 0', throttle_duration_sec=30.0)
         commanded = (0.0 if side == 'down'
                      else float(self._controls.get('range') or 0.0))
         msg.sample_rate = derive_sample_rate(
-            sub, bins, sv, commanded_range_m=commanded,
+            sub, GRID_BINS, sv, commanded_range_m=commanded,
             fallback_rate=self._sample_rate)
         msg.samples_per_beam = bins
-        msg.sample0 = 0
+        # Near-field gate: the first (GRID_BINS - bins) grid samples are omitted,
+        # so the delivered data starts at grid sample index sample0.
+        msg.sample0 = max(0, GRID_BINS - bins)
         # rx_angles/tx_angles are the *steering* angle applied to the beam
         # (per the RawSonarImage spec) -- 0 for a fixed, unsteered single-beam
         # sidescan. The transducer's physical look direction (port out / stbd

--- a/garmin_sidescan/garmin_sidescan/node.py
+++ b/garmin_sidescan/garmin_sidescan/node.py
@@ -15,10 +15,8 @@ transmit on/off and range over the GCV TCP command port
 payloads on ``~/debug/raw`` for offline re-decode.
 
 Safety: the node asserts transmit OFF at startup and never pings without an
-explicit command.  While transmitting, a sound-speed watchdog stops the sonar
-if the sound speed reads NaN / 0 / out-of-water for ``sv_timeout`` seconds, so
-a dry transducer cannot overheat.  The whole mechanism has a dynamic master
-switch (``sound_speed_safety_enabled``).
+explicit command.  The GCV stops pinging on its own when out of the water, so
+no external sound-speed interlock is needed to protect the transducer.
 """
 import math
 import socket
@@ -34,7 +32,6 @@ import rclpy
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
-from rosidl_runtime_py.utilities import get_message
 from sensor_msgs.msg import Range, Temperature
 from std_msgs.msg import Bool, String, UInt8MultiArray
 from std_srvs.srv import SetBool
@@ -113,44 +110,13 @@ def transmit_state_after(commanded_on, send_ok, prior):
     Return the transmit state to record after issuing a command.
 
     A failed OFF must not be recorded as OFF: the sonar may still be pinging,
-    so we stay True and let the watchdog keep retrying.  A successful command
-    records the commanded state.  A failed ON keeps the ``prior`` state rather
-    than asserting OFF: if the sonar may already be pinging (e.g. a preceding
-    OFF that also failed left ``prior`` True, then an auto-resume ON send fails
-    too), recording OFF would falsely disarm the watchdog over a live, dry
-    transducer.
+    so we stay True and retry.  A successful command records the commanded
+    state.  A failed ON keeps the ``prior`` state rather than asserting a state
+    the command never achieved.
     """
     if not commanded_on:
         return not send_ok
     return True if send_ok else prior
-
-
-def watchdog_action(*, safety_enabled, transmitting, has_sv_topic,
-                    require_sv, sv_age, sv_timeout):
-    """
-    Decide whether the sound-speed watchdog must stop transmit.
-
-    Returns ``(stop, kind)`` where ``stop`` is a bool and ``kind`` is
-    ``''`` (no action), ``'no_source'`` (require_sound_speed set but no
-    sound-speed source configured), or ``'stale'`` (no valid reading within
-    ``sv_timeout``).
-
-    The watchdog runs independently of *require_sound_speed*: that flag governs
-    whether a fresh reading is required *before* transmitting, while the
-    watchdog must stop a dry transducer whenever it is (or may be) transmitting.
-    With no sound-speed source it mirrors ``_guard_transmit_on``: under
-    require_sv it must stop (the guard refuses to *start* here, so a
-    maybe-transmitting state reached without a guard must not be left pinging);
-    without require_sv (bench testing) there is nothing to evaluate, so it
-    leaves transmit untouched.
-    """
-    if not safety_enabled or not transmitting:
-        return False, ''
-    if not has_sv_topic:
-        return (True, 'no_source') if require_sv else (False, '')
-    if sv_age is None or sv_age > sv_timeout:
-        return True, 'stale'
-    return False, ''
 
 
 def range_in_bounds(meters, range_min, range_max):
@@ -190,7 +156,7 @@ def temperature_publish_due(temp_c, last_c, elapsed_s, heartbeat_s=2.0):
 
 
 class GarminSidescanNode(Node):
-    """Driver node: GCV imagery in, RawSonarImage out, transmit under safety."""
+    """Driver node: GCV imagery in, RawSonarImage out, transmit on command."""
 
     def __init__(self):
         super().__init__('garmin_sidescan')
@@ -258,28 +224,23 @@ class GarminSidescanNode(Node):
                 floating_point_range=[
                     FloatingPointRange(from_value=0.0, to_value=range_max, step=0.0)]))
         # transmit on/off as a bridgeable marine_control. Holds ACTUAL transmit
-        # state, reconciled by the watchdog so the operator panel never lies.
+        # state, reconciled by a timer so the operator panel never lies.
         self.declare_parameter(
             'transmit', False,
-            ParameterDescriptor(
-                description=('Sonar transmit on/off (safety-guarded by the '
-                             'sound-speed watchdog).')))
+            ParameterDescriptor(description='Sonar transmit on/off.'))
         # TVG / interference frames are GCV-10-derived and unverified on the
         # GCV-20 (TVG is display-side there); expose them but allow opting out.
         self.declare_parameter('expose_gcv10_controls', True)
 
-        # sound-speed watchdog
-        self.declare_parameter('sound_speed_safety_enabled', True)
-        # Generic default; a platform launch sets the absolute topic.
-        self.declare_parameter('sound_speed_topic', 'sound_speed')
-        self.declare_parameter('sound_speed_type', 'marine_interfaces/msg/SoundSpeed')
-        self.declare_parameter('sound_speed_field', 'sound_speed')
-        self.declare_parameter('sv_min', 1400.0)
-        self.declare_parameter('sv_max', 1600.0)
-        self.declare_parameter('sv_timeout', 12.0)
-        self.declare_parameter('require_sound_speed', True)
-        self.declare_parameter('auto_resume', True)
-        self.declare_parameter('resume_valid_samples', 3)     # sustained-valid before resume
+        # Sound speed (m/s) used to convert the device's per-ping display range
+        # into the published RawSonarImage scale (sample_rate) and stamped into
+        # ping_info.sound_speed. This is the DEVICE's assumed sound speed for
+        # scale reconstruction, not a live measurement: the GCV reports range in
+        # metres already, so any consistent value round-trips the geometry, and
+        # the device exposes no water-type / sound-speed setting (it uses a fixed
+        # internal nominal). A consumer that re-applies its own sound-speed
+        # correction must match this value. Default 1500 m/s.
+        self.declare_parameter('sound_speed', 1500.0)
 
         self._gcv_ip = self._p('gcv_ip')
         self._ctrl_port = int(self._p('control_port'))
@@ -311,29 +272,16 @@ class GarminSidescanNode(Node):
                 'falling back to auto-detect')
             self._device = 'auto'
         self._debug_raw = bool(self._p('debug_raw'))
-        self._sv_topic = self._p('sound_speed_topic')
-        self._sv_field = self._p('sound_speed_field')
-        self._sv_min = float(self._p('sv_min'))
-        self._sv_max = float(self._p('sv_max'))
-        self._sv_timeout = float(self._p('sv_timeout'))
-        self._require_sv = bool(self._p('require_sound_speed'))
-        self._auto_resume = bool(self._p('auto_resume'))
-        self._resume_valid_samples = max(1, int(self._p('resume_valid_samples')))
-        self._safety_enabled = bool(self._p('sound_speed_safety_enabled'))
+        self._sound_speed = float(self._p('sound_speed'))
 
         # state
-        self._tx_lock = threading.Lock()      # guards transmit/latch state changes
+        self._tx_lock = threading.Lock()      # guards transmit state changes
         self._send_lock = threading.Lock()    # serializes TCP command sends
         self._transmitting = False
         # True while _reconcile_transmit_param mirrors actual state into the
         # `transmit` param, so _on_param_set skips re-issuing a transmit command.
         self._tx_sync = False
         self._control_server = None
-        self._safety_latched = False
-        self._last_valid_sv_t = None
-        self._last_valid_sv_value = 0.0
-        self._last_sv_value = float('nan')
-        self._valid_streak = 0
         self._ping_count = {s: 0 for s in SIDES}
         self._range_min = float(self._p('range_min_m'))
         self._range_max = float(self._p('range_max_m'))
@@ -409,29 +357,11 @@ class GarminSidescanNode(Node):
         self.create_subscription(RadarControlValue, '~/change_state',
                                  self._on_control_value, 10)
 
-        if self._sv_topic:
-            try:
-                sv_type = get_message(self._p('sound_speed_type'))
-                # Default RELIABLE depth-10 matches sound_speed_bridge's publisher
-                # QoS; a BEST_EFFORT source would need this adjusted to match, or
-                # the watchdog would silently receive nothing.
-                self.create_subscription(sv_type, self._sv_topic, self._on_sound_speed, 10)
-                self.get_logger().info(
-                    f'sound-speed watchdog on {self._sv_topic} '
-                    f'(valid {self._sv_min}-{self._sv_max} m/s, timeout {self._sv_timeout}s)')
-            except (ValueError, ImportError, AttributeError) as exc:
-                self.get_logger().error(
-                    f'could not subscribe to sound speed ({exc}); watchdog DISABLED '
-                    '- transmit refused unless require_sound_speed:=false')
-                self._sv_topic = ''
-        else:
-            self.get_logger().warn('sound_speed_topic empty: watchdog disabled')
-
         self.add_on_set_parameters_callback(self._on_param_set)
 
         # marine_control device panel (bridgeable; rendered by rqt_marine_control).
         # transmit + range for now; TVG/interference await enum support in the lib.
-        # Created before the timers so the watchdog can reconcile the transmit param.
+        # Created before the timers so the reconcile timer can mirror the transmit param.
         self._control_server = ControlServer(self)
         self._control_server.bind_parameter('transmit', group='sonar')
         self._control_server.bind_parameter('range_m', units='m', group='sonar')
@@ -446,7 +376,7 @@ class GarminSidescanNode(Node):
         threading.Thread(
             target=self._aux_loop, name='gcv_config', daemon=True,
             args=(CONFIG_GROUP, CONFIG_PORT, self._pub_raw_config, None)).start()
-        self.create_timer(0.5, self._watchdog)
+        self.create_timer(0.5, self._reconcile_transmit_param)
         self.create_timer(2.0, self._publish_status)
         self.create_timer(1.0, self._publish_diagnostics)
 
@@ -470,7 +400,7 @@ class GarminSidescanNode(Node):
                     ok = True
                 time.sleep(0.3)
             # If every OFF send failed the GCV may be pinging; stay "on" so
-            # the watchdog keeps retrying rather than reporting a false OFF.
+            # status reflects reality rather than reporting a false OFF.
             self._transmitting = not ok
         self._publish_tx_state()
         if ok:
@@ -478,7 +408,7 @@ class GarminSidescanNode(Node):
         else:
             self.get_logger().error(
                 'startup: could not assert transmit OFF (GCV unreachable?); '
-                'assuming sonar may be pinging - watchdog will retry')
+                'assuming sonar may be pinging')
         if range_m > 0:
             if self._send(build_range_cmd(range_m)):
                 self._controls['range'] = f'{range_m:.1f}'
@@ -486,11 +416,7 @@ class GarminSidescanNode(Node):
             else:
                 self.get_logger().error(f'startup: range command ({range_m} m) failed to send')
         if want_on:
-            ok, msg = self._guard_transmit_on()
-            if ok:
-                self._set_transmit(True, 'startup (transmit_on_startup)')
-            else:
-                self.get_logger().warn(f'startup transmit_on_startup refused: {msg}')
+            self._set_transmit(True, 'startup (transmit_on_startup)')
 
     # ----- TCP command send --------------------------------------------------
     def _send(self, data):
@@ -510,26 +436,22 @@ class GarminSidescanNode(Node):
     def _set_transmit(self, on, reason):
         with self._tx_lock:
             ok = self._send(TRANSMIT_ON if on else TRANSMIT_OFF)
-            # A failed OFF keeps _transmitting True so the watchdog keeps
-            # retrying and status reflects reality; a failed ON keeps the prior
-            # state so an auto-resume ON failing after a failed OFF can't
-            # falsely report OFF (see transmit_state_after).
+            # A failed OFF keeps _transmitting True so status reflects reality
+            # (the sonar may still be pinging) and we retry; a failed ON keeps
+            # the prior state (see transmit_state_after).
             self._transmitting = transmit_state_after(on, ok, prior=self._transmitting)
-            if on and ok:
-                self._safety_latched = False
         if not on and not ok:
             self.get_logger().error(
                 f'transmit OFF command FAILED ({reason}); sonar may still be '
                 'pinging - will retry')
         else:
-            log = self.get_logger().error if (not on and reason.startswith('SAFETY')) \
-                else self.get_logger().info
-            log(f'transmit {"ON" if self._transmitting else "OFF"} ({reason})')
+            self.get_logger().info(
+                f'transmit {"ON" if self._transmitting else "OFF"} ({reason})')
         self._publish_tx_state()
 
     def _publish_tx_state(self):
         self._pub_tx.publish(Bool(data=bool(self._transmitting)))
-        # keep the operator-control mirror in sync (incl. watchdog-driven changes)
+        # keep the operator-control mirror in sync with actual transmit state
         self._controls['status'] = 'transmit' if self._transmitting else 'standby'
         self._publish_control_set()
 
@@ -542,46 +464,14 @@ class GarminSidescanNode(Node):
         failed OFF send reports that the sonar may still be transmitting.
         """
         if on:
-            ok, msg = self._guard_transmit_on()
-            if not ok:
-                self.get_logger().warn(f'transmit ON refused: {msg}')
-                return False, msg
             self._set_transmit(True, 'request')
             if self._transmitting:
                 return True, 'transmitting'
             return False, 'transmit ON command failed to send'
-        self._safety_latched = False    # explicit operator off: no auto-resume
         self._set_transmit(False, 'request')
         if self._transmitting:
             return False, 'transmit OFF command failed to send; sonar may still be pinging'
         return True, 'transmit off'
-
-    # ----- transmit guard ----------------------------------------------------
-    def _sv_age(self):
-        if self._last_valid_sv_t is None:
-            return None
-        return time.monotonic() - self._last_valid_sv_t
-
-    def _current_sound_speed(self):
-        """Last valid sound speed if still fresh, else 0.0 (unavailable)."""
-        age = self._sv_age()
-        if age is None or age > self._sv_timeout:
-            return 0.0
-        return self._last_valid_sv_value
-
-    def _guard_transmit_on(self):
-        if not self._safety_enabled or not self._require_sv:
-            return True, ''
-        if not self._sv_topic:
-            return False, ('sound_speed_topic not configured; refusing to transmit '
-                           '(override with require_sound_speed:=false)')
-        age = self._sv_age()
-        if age is None:
-            return False, 'no valid sound speed received yet; refusing to transmit'
-        if age > self._sv_timeout:
-            return False, (f'last valid sound speed was {age:.1f}s ago '
-                           f'(>{self._sv_timeout}s); transducer may be out of water')
-        return True, ''
 
     def _on_set_transmit(self, req, resp):
         resp.success, resp.message = self._request_transmit(bool(req.data))
@@ -653,48 +543,14 @@ class GarminSidescanNode(Node):
             return
         self._publish_control_set()
 
-    # ----- sound-speed watchdog ---------------------------------------------
-    def _extract_field(self, msg):
-        val = msg
-        for part in self._sv_field.split('.'):
-            val = getattr(val, part)
-        return float(val)
-
-    def _on_sound_speed(self, msg):
-        try:
-            sv = self._extract_field(msg)
-        except (AttributeError, TypeError, ValueError) as exc:
-            self.get_logger().warn(
-                f'sound-speed field "{self._sv_field}" unreadable: {exc}',
-                throttle_duration_sec=10.0)
-            return
-        self._last_sv_value = sv
-        if math.isfinite(sv) and self._sv_min <= sv <= self._sv_max:
-            self._last_valid_sv_t = time.monotonic()
-            self._last_valid_sv_value = sv
-            self._valid_streak += 1
-            # Resume only after sustained recovery, and only if the full
-            # transmit guard (master switch, freshness) still passes — a
-            # single in-range sample must not re-energize a dry transducer.
-            if (self._safety_latched and self._auto_resume and self._safety_enabled
-                    and self._valid_streak >= self._resume_valid_samples):
-                ok, _msg = self._guard_transmit_on()
-                if ok:
-                    self.get_logger().info(
-                        f'sound speed recovered ({sv:.1f} m/s, '
-                        f'{self._valid_streak} samples); auto-resuming transmit')
-                    self._set_transmit(True, 'auto_resume after sustained recovery')
-        else:
-            self._valid_streak = 0
-
     def _reconcile_transmit_param(self):
         """
         Mirror actual transmit state into the `transmit` parameter.
 
-        Runs on the executor thread (the watchdog timer) so a watchdog- or
-        startup-thread-driven transmit change reaches the ControlServer echo
-        without a cross-thread set_parameters. The _tx_sync guard keeps
-        _on_param_set from re-issuing a transmit command for this mirror write.
+        Runs on the executor thread (the reconcile timer) so a startup-thread-
+        driven transmit change reaches the ControlServer echo without a
+        cross-thread set_parameters. The _tx_sync guard keeps _on_param_set
+        from re-issuing a transmit command for this mirror write.
         """
         if not self.has_parameter('transmit'):
             return
@@ -711,30 +567,6 @@ class GarminSidescanNode(Node):
             self._tx_sync = False
         if self._control_server is not None:
             self._control_server.publish_state()
-
-    def _watchdog(self):
-        # Reconcile first so an async transmit change (watchdog stop last tick,
-        # startup thread, auto-resume) is reflected in the panel promptly.
-        self._reconcile_transmit_param()
-        age = self._sv_age()
-        stop, kind = watchdog_action(
-            safety_enabled=self._safety_enabled,
-            transmitting=self._transmitting,
-            has_sv_topic=bool(self._sv_topic),
-            require_sv=self._require_sv,
-            sv_age=age,
-            sv_timeout=self._sv_timeout)
-        if not stop:
-            return
-        self._safety_latched = True
-        if kind == 'no_source':
-            reason = ('SAFETY: require_sound_speed set but no sound-speed source '
-                      'configured; stopping ping to protect transducer')
-        else:
-            shown = 'never' if age is None else f'{age:.1f}s ago'
-            reason = (f'SAFETY: sound speed invalid/stale (last valid {shown}, '
-                      f'value={self._last_sv_value}); stopping ping to protect transducer')
-        self._set_transmit(False, reason)
 
     # ----- imagery receive + decode -----------------------------------------
     def _open_mcast(self, group, port):
@@ -961,7 +793,7 @@ class GarminSidescanNode(Node):
         # Per-channel frame so TF orients each transducer (see FRAME_SUFFIX).
         msg.header.frame_id = f'{self._frame_id}_{FRAME_SUFFIX[side]}'
         msg.ping_info.frequency = self._freq[side]
-        sv = self._current_sound_speed()
+        sv = self._sound_speed
         msg.ping_info.sound_speed = sv
         # Derive sample_rate so a consumer recovers range = sv*bins/(2*rate).
         # The range source is the ping's OWN sub-header v2 (per channel, tracks
@@ -996,7 +828,6 @@ class GarminSidescanNode(Node):
     def _publish_diagnostics(self):
         now = time.monotonic()
         ping_age = None if self._last_ping_t is None else now - self._last_ping_t
-        sv_age = self._sv_age()
 
         # Imagery stream
         lvl, msg = imagery_diag_level(self._transmitting, ping_age)
@@ -1012,33 +843,21 @@ class GarminSidescanNode(Node):
                                f"{self._ping_count['down']}"),
             ])
 
-        # Transmit + sound-speed safety. WARN if the device-reported transmit
-        # state (from the :50050 status frame) disagrees with what we commanded,
-        # or if we are (maybe) transmitting on a stale/absent sound speed.
+        # Transmit state. WARN if the device-reported transmit state (from the
+        # :50050 status frame) disagrees with what we commanded.
         dev_tx = self._device_transmitting
         mismatch = dev_tx is not None and dev_tx != self._transmitting
-        sv_stale = self._transmitting and self._safety_enabled and (
-            sv_age is None or sv_age > self._sv_timeout)
-        tx_lvl = DiagnosticStatus.OK
-        tx_msg = 'transmitting' if self._transmitting else 'standby'
-        if mismatch:
-            tx_lvl = DiagnosticStatus.WARN
-            tx_msg = f'commanded {self._transmitting} but device reports {dev_tx}'
-        elif sv_stale:
-            tx_lvl = DiagnosticStatus.WARN
-            tx_msg = 'transmitting without a fresh sound speed'
+        tx_lvl = DiagnosticStatus.WARN if mismatch else DiagnosticStatus.OK
+        tx_msg = (f'commanded {self._transmitting} but device reports {dev_tx}'
+                  if mismatch
+                  else ('transmitting' if self._transmitting else 'standby'))
         transmit = DiagnosticStatus(
-            name='garmin_sidescan: transmit/safety', hardware_id=self._gcv_ip,
+            name='garmin_sidescan: transmit', hardware_id=self._gcv_ip,
             level=tx_lvl, message=tx_msg, values=[
                 KeyValue(key='commanded_transmitting', value=str(self._transmitting)),
                 KeyValue(key='device_transmitting',
                          value='unknown' if dev_tx is None else str(dev_tx)),
-                KeyValue(key='safety_enabled', value=str(self._safety_enabled)),
-                KeyValue(key='require_sound_speed', value=str(self._require_sv)),
-                KeyValue(key='safety_latched', value=str(self._safety_latched)),
-                KeyValue(key='sound_speed_mps', value=f'{self._last_sv_value:.1f}'),
-                KeyValue(key='sound_speed_age_s',
-                         value='n/a' if sv_age is None else f'{sv_age:.1f}'),
+                KeyValue(key='sound_speed_mps', value=f'{self._sound_speed:.1f}'),
             ])
 
         arr = DiagnosticArray()
@@ -1047,14 +866,9 @@ class GarminSidescanNode(Node):
         self._pub_diag.publish(arr)
 
     def _publish_status(self):
-        age = self._sv_age()
-        age_s = 'n/a' if age is None else f'{age:.1f}s'
         self._pub_status.publish(String(data=(
             f'tx={"ON" if self._transmitting else "OFF"} '
-            f'safety={"on" if self._safety_enabled else "OFF"} '
-            f'require_sv={self._require_sv} '
-            f'latched={self._safety_latched} '
-            f'sv={self._last_sv_value:.1f} sv_age={age_s} '
+            f'sound_speed={self._sound_speed:.1f} '
             f'pings(port/stbd/down)={self._ping_count["port"]}/'
             f'{self._ping_count["stbd"]}/{self._ping_count["down"]}')))
         # Re-publish the control set on the status timer so a late or udp-bridged
@@ -1091,7 +905,7 @@ class GarminSidescanNode(Node):
                 range_request = meters
             elif p.name == 'transmit':
                 transmit_request = bool(p.value)  # applied below (or mirror-only)
-            elif p.name in ('sound_speed_safety_enabled', 'debug_raw'):
+            elif p.name == 'debug_raw':
                 pass  # always acceptable; applied below
             elif p.name != 'use_sim_time' and self.has_parameter(p.name):
                 # Every other declared parameter is read once at startup. Silently
@@ -1128,21 +942,13 @@ class GarminSidescanNode(Node):
         if transmit_request is not None and not self._tx_sync:
             ok, reason = self._request_transmit(transmit_request)
             if not ok:
-                # Refused (watchdog guard) or not achieved (a failed send can
-                # leave the sonar possibly still pinging): reject so the param
-                # stays at the actual transmit state, not the request.
+                # Not achieved (a failed send can leave the sonar possibly still
+                # pinging): reject so the param stays at the actual transmit
+                # state, not the request.
                 return SetParametersResult(successful=False, reason=reason)
 
         for p in params:
-            if p.name == 'sound_speed_safety_enabled':
-                self._safety_enabled = bool(p.value)
-                if self._safety_enabled:
-                    self.get_logger().info('sound-speed safety mechanism ENABLED')
-                else:
-                    self.get_logger().warn(
-                        'sound-speed safety mechanism DISABLED (watchdog auto-stop and '
-                        'transmit guard off - dry-transducer protection is not active)')
-            elif p.name == 'debug_raw':
+            if p.name == 'debug_raw':
                 self._debug_raw = bool(p.value)
                 self.get_logger().info(
                     'debug_raw ON - publishing raw payloads on ~/debug/raw'
@@ -1152,8 +958,8 @@ class GarminSidescanNode(Node):
     def destroy_node(self):
         """Stop the receive loop and assert transmit off on shutdown."""
         self._running = False
-        # Retry the OFF; a single dropped frame on shutdown must not leave a
-        # dry transducer pinging. _send already swallows OSError -> bool.
+        # Retry the OFF; a single dropped frame on shutdown must not leave the
+        # sonar pinging unattended. _send already swallows OSError -> bool.
         off_ok = False
         for _ in range(3):
             if self._send(TRANSMIT_OFF):

--- a/garmin_sidescan/launch/garmin_sidescan.launch.py
+++ b/garmin_sidescan/launch/garmin_sidescan.launch.py
@@ -2,12 +2,9 @@
 Example launch for the Garmin GCV sidescan driver.
 
 Neutral defaults only: no ROS namespace, ``frame_id`` ``garmin_sidescan``, and the
-node's own safe defaults (transmit OFF at startup, sound-speed interlock on,
-sound-speed topic ``sound_speed``). A platform launch is expected to wrap this
-to set the namespace, frame prefix, the GCV's address, the local multicast
-interface, and the absolute sound-speed topic -- the same example-vs-wrapper
-split ``sound_speed_bridge`` uses (``aml_svs.launch.py`` here vs. a downstream
-platform launch).
+node's own safe defaults (transmit OFF at startup). A platform launch is expected
+to wrap this to set the namespace, frame prefix, the GCV's address, and the local
+multicast interface.
 """
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument

--- a/garmin_sidescan/package.xml
+++ b/garmin_sidescan/package.xml
@@ -4,16 +4,14 @@
   <name>garmin_sidescan</name>
   <version>0.0.1</version>
   <description>ROS 2 driver for the Garmin GCV-10/20 sidescan sonar: decodes the
-  Marine-Network imagery multicast into marine_acoustic_msgs/RawSonarImage,
-  controls transmit/range over the GCV TCP command port, and interlocks
-  transmit on a sound-speed watchdog to protect a dry transducer.</description>
+  Marine-Network imagery multicast into marine_acoustic_msgs/RawSonarImage and
+  controls transmit/range over the GCV TCP command port.</description>
   <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
   <license>BSD-3-Clause</license>
 
   <depend>rclpy</depend>
   <depend>marine_acoustic_msgs</depend>
   <depend>marine_control_py</depend>
-  <depend>marine_interfaces</depend>
   <depend>marine_radar_control_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -1,9 +1,8 @@
 """
-Unit tests for the transmit-state safety rule.
+Unit tests for the transmit-state rule.
 
 The critical invariant: a transmit-OFF command whose TCP send FAILED must not
-be recorded as OFF, or the watchdog would stop retrying and a dry transducer
-could keep pinging while everything reports OFF.
+be recorded as OFF, or the sonar could keep pinging while everything reports OFF.
 """
 import threading
 import types
@@ -19,7 +18,6 @@ from garmin_sidescan.node import (
     temperature_plausible,
     temperature_publish_due,
     transmit_state_after,
-    watchdog_action,
 )
 
 
@@ -62,9 +60,8 @@ def test_failed_on_from_off_stays_off():
 
 
 def test_failed_on_while_possibly_pinging_stays_transmitting():
-    # safety-critical: a prior failed OFF left prior=True (may still be pinging);
-    # an auto-resume ON whose send also fails must NOT report OFF and disarm the
-    # watchdog over a live, dry transducer.
+    # a prior failed OFF left prior=True (may still be pinging); an ON whose send
+    # also fails must NOT report OFF over a sonar that may still be transmitting.
     assert transmit_state_after(commanded_on=True, send_ok=False, prior=True) is True
 
 
@@ -75,46 +72,6 @@ def test_successful_off_is_not_transmitting():
 def test_failed_off_stays_transmitting():
     # the safety-critical case: OFF send failed -> assume still pinging
     assert transmit_state_after(commanded_on=False, send_ok=False, prior=False) is True
-
-
-# ----- watchdog decision (watchdog_action) -------------------------------
-
-def _wd(**kw):
-    base = {'safety_enabled': True, 'transmitting': True, 'has_sv_topic': True,
-            'require_sv': True, 'sv_age': 0.0, 'sv_timeout': 5.0}
-    base.update(kw)
-    return watchdog_action(**base)
-
-
-def test_watchdog_idle_when_safety_disabled():
-    assert _wd(safety_enabled=False) == (False, '')
-
-
-def test_watchdog_idle_when_not_transmitting():
-    assert _wd(transmitting=False) == (False, '')
-
-
-def test_watchdog_fresh_reading_no_action():
-    assert _wd(sv_age=1.0) == (False, '')
-
-
-def test_watchdog_stale_reading_stops():
-    assert _wd(sv_age=9.0) == (True, 'stale')
-
-
-def test_watchdog_never_received_stops():
-    assert _wd(sv_age=None) == (True, 'stale')
-
-
-def test_watchdog_no_source_with_require_sv_stops():
-    # require_sv + no sound-speed source while (maybe) transmitting: the guard
-    # refuses to start here, so the watchdog must stop rather than dry-ping.
-    assert _wd(has_sv_topic=False, require_sv=True) == (True, 'no_source')
-
-
-def test_watchdog_no_source_without_require_sv_leaves_transmit():
-    # bench testing (require_sound_speed:=false): nothing to evaluate, no stop
-    assert _wd(has_sv_topic=False, require_sv=False) == (False, '')
 
 
 # ----- range bounds (range_in_bounds) ------------------------------------
@@ -158,7 +115,6 @@ class _FakeNode:
         self._range_min = 1.0
         self._range_max = 60.0
         self._controls = {}
-        self._safety_enabled = True
         self.publishes = 0
         # transmit-control adoption
         self._tx_sync = False
@@ -188,7 +144,7 @@ class _FakeNode:
         if self._tx_achieves:
             self._transmitting = on
             return True, 'ok'
-        return False, 'refused'   # guard refused: actual state unchanged
+        return False, 'refused'   # not achieved: actual state unchanged
 
 
 def _param(name, value):
@@ -212,9 +168,9 @@ def test_batch_rejects_static_param_without_sending_range():
     # rejected atomically -- the range command must NOT have been sent and the
     # UI mirror must NOT have been updated, or the param store desyncs from the
     # hardware/UI.
-    node = _FakeNode(static_params=('sv_min',))
+    node = _FakeNode(static_params=('freq_port_hz',))
     result = _on_param_set(
-        node, [_param('range_m', 30.0), _param('sv_min', 1400.0)])
+        node, [_param('range_m', 30.0), _param('freq_port_hz', 800000.0)])
     assert result.successful is False
     assert node.sends == []
     assert 'range' not in node._controls
@@ -223,9 +179,9 @@ def test_batch_rejects_static_param_without_sending_range():
 def test_batch_rejection_independent_of_param_order():
     # Same as above but static param first: the validate-all pre-pass must catch
     # it regardless of ordering, still without sending the range command.
-    node = _FakeNode(static_params=('sv_min',))
+    node = _FakeNode(static_params=('freq_port_hz',))
     result = _on_param_set(
-        node, [_param('sv_min', 1400.0), _param('range_m', 30.0)])
+        node, [_param('freq_port_hz', 800000.0), _param('range_m', 30.0)])
     assert result.successful is False
     assert node.sends == []
 
@@ -248,9 +204,9 @@ def test_transmit_request_applied_when_achieved():
     assert node._transmitting is True
 
 
-def test_transmit_request_rejected_when_refused():
-    # The watchdog guard refuses ON: reject the set so the param stays at the
-    # actual (off) transmit state rather than falsely reporting on.
+def test_transmit_request_rejected_when_not_achieved():
+    # The ON request isn't achieved (e.g. send failed): reject the set so the
+    # param stays at the actual (off) transmit state rather than falsely on.
     node = _FakeNode(tx_achieves=False)
     result = _on_param_set(node, [_param('transmit', True)])
     assert result.successful is False
@@ -430,11 +386,8 @@ def test_status_heartbeat_republishes_control_set():
     # -- or a late / udp-bridged rqt subscriber never populates the control panel.
     node = _FakeNode()
     node._transmitting = False
-    node._require_sv = True
-    node._safety_latched = False
-    node._last_sv_value = 1500.0
+    node._sound_speed = 1500.0
     node._ping_count = {'port': 0, 'stbd': 0, 'down': 0}
-    node._sv_age = lambda: None
     node._pub_status = types.SimpleNamespace(publish=lambda msg: None)
     GarminSidescanNode._publish_status(node)
     assert node.publishes == 1
@@ -468,7 +421,7 @@ def test_make_sonar_msg_down_never_takes_commanded_range_fallback():
     def fake(side):
         return types.SimpleNamespace(
             _frame_id='gs', _freq={side: 0.0},
-            _current_sound_speed=lambda: 1500.0,
+            _sound_speed=1500.0,
             _controls={'range': '50.0'},
             _bytes_per_sample=2, _sample_rate=0.0, _sonar_dtype=0,
             _make_sonar_msg=GarminSidescanNode._make_sonar_msg)

--- a/garmin_sidescan/test/test_safety.py
+++ b/garmin_sidescan/test/test_safety.py
@@ -437,6 +437,41 @@ def test_make_sonar_msg_down_never_takes_commanded_range_fallback():
     assert down_msg.sample_rate == 0.0
 
 
+def test_make_sonar_msg_encodes_near_field_gate():
+    # The GCV delivers the gated TAIL of a fixed 2048-sample line spanning
+    # [0, display_range]; the omitted near-field head must be exposed as sample0
+    # so a consumer places delivered sample j at range sv*(sample0+j)/(2*rate),
+    # NOT starting at range 0. Validated against the device's own down-look
+    # bottom echo: display_range 1.843 m, 1943 delivered bins -> sample0 105,
+    # and the bottom-echo bin (319) recovers the reported bottom_range_m (~0.381 m).
+    from builtin_interfaces.msg import Time
+    from garmin_sidescan.decode import GRID_BINS, Subheader
+
+    sub = Subheader(channel=2, layer=0x0d, v1_tag=0x12,
+                    bottom_range_m=0.381, display_range_m=1.843,
+                    near_field_m=0.0985)
+    node = types.SimpleNamespace(
+        _frame_id='gs', _freq={'down': 0.0}, _sound_speed=1500.0,
+        _controls={'range': '0.0'}, _bytes_per_sample=2, _sample_rate=0.0,
+        _sonar_dtype=0, get_logger=lambda: _FakeLogger())
+    samples = bytes(2 * 1943)                    # 1943 uint16 bins
+    stamp = types.SimpleNamespace(to_msg=lambda: Time())
+    msg = GarminSidescanNode._make_sonar_msg(node, 'down', samples, stamp, sub=sub)
+
+    assert msg.samples_per_beam == 1943
+    assert msg.sample0 == GRID_BINS - 1943       # == 105, the near-field gate
+    # full display range recovers from the FULL grid (sample0 + bins)
+    full = 1500.0 * (msg.sample0 + msg.samples_per_beam) / (2.0 * msg.sample_rate)
+    assert abs(full - 1.843) < 1e-3
+    # the bottom echo at delivered bin 319 -> grid index sample0+319 -> ~0.381 m
+    range_319 = 1500.0 * (msg.sample0 + 319) / (2.0 * msg.sample_rate)
+    assert abs(range_319 - 0.381) < 5e-3
+    # a consumer that ignored sample0 would shift every sample inward by the
+    # near-field offset (~0.094 m here) and badly misplace the bottom
+    ignored = 1500.0 * 319 / (2.0 * msg.sample_rate)
+    assert range_319 - ignored > 0.08
+
+
 def test_emit_ping_skips_implausible_nadir_values():
     from garmin_sidescan.decode import ScanLine, Subheader
 

--- a/garmin_sidescan/tools/README.md
+++ b/garmin_sidescan/tools/README.md
@@ -47,7 +47,7 @@ loopback (`--iface-ip 127.0.0.1`, TTL 0) so nothing leaves the host.
 ```bash
 # terminal 1 — the driver under test
 ros2 run garmin_sidescan garmin_sidescan --ros-args \
-    -p iface_ip:=127.0.0.1 -p filter_src:=false -p require_sound_speed:=false
+    -p iface_ip:=127.0.0.1 -p filter_src:=false
 # terminal 2 — the replay
 python3 tools/replay_debug_raw.py BAG --start 100 --end 300
 # terminal 3 — watch the output (sensor topics are best-effort; a

--- a/garmin_sidescan/tools/garmin_marine_network_proxy.py
+++ b/garmin_sidescan/tools/garmin_marine_network_proxy.py
@@ -32,8 +32,8 @@ driver expects them, so the *unmodified* driver runs on gabby:
   and serializes them; connections are handled on a thread each regardless.
 
 Every UDP relay is one-way GCV->ROS and nothing reaches the GCV except the
-driver's own control frames, so the sonar's transmit safety (the sound-speed
-watchdog) stays entirely in the driver on gabby. The status/config streams are
+driver's own control frames, so all sonar transmit control stays entirely in
+the driver on gabby. The status/config streams are
 relayed by default so the driver's ``debug_raw`` capture records them; relaying
 status also feeds the driver's (otherwise-starved) device transmit-flag path.
 

--- a/garmin_sidescan/tools/replay_debug_raw.py
+++ b/garmin_sidescan/tools/replay_debug_raw.py
@@ -11,7 +11,7 @@ sub-header scaling, ``nadir_depth``) runs exactly as on the boat.  Point a
 Run the driver against the replay on the same host::
 
     ros2 run garmin_sidescan garmin_sidescan --ros-args \
-        -p iface_ip:=127.0.0.1 -p filter_src:=false -p require_sound_speed:=false
+        -p iface_ip:=127.0.0.1 -p filter_src:=false
 
     python3 replay_debug_raw.py BAG [--rate 1.0] [--start S] [--end S]
 

--- a/garmin_sidescan/tools/sidescan_waterfall.py
+++ b/garmin_sidescan/tools/sidescan_waterfall.py
@@ -40,7 +40,8 @@ import collections
 import sys
 
 from garmin_sidescan.decode import (
-    D807, dark_layer, EB07, echo_layer, generation_from_layers, PingAssembler)
+    D807, dark_layer, EB07, echo_layer, generation_from_layers, GRID_BINS,
+    PingAssembler)
 import numpy as np
 from rclpy.serialization import deserialize_message
 import rosbag2_py
@@ -120,10 +121,11 @@ def read_pings_messages(bag, start, end):
     Build the same ``{channel: [(t, sub, samples)]}`` from ``sonar_image_*``.
 
     The decoded-message source (#35): per-ping scale recovered from
-    ``sample_rate`` (``range = sound_speed * bins / (2 * rate)``), the bottom
-    line from ``~/nadir_depth`` when recorded.  Bags recorded before the
-    driver published a scale (``sample_rate`` = 0) cannot be rendered from
-    messages -- use the ``debug/raw`` source for those.
+    ``sample_rate`` with the near-field gate from ``sample0``
+    (``range = sound_speed * (sample0 + j) / (2 * rate)`` for delivered sample
+    ``j``), the bottom line from ``~/nadir_depth`` when recorded.  Bags recorded
+    before the driver published a scale (``sample_rate`` = 0) cannot be rendered
+    from messages -- use the ``debug/raw`` source for those.
     """
     from marine_acoustic_msgs.msg import RawSonarImage
     from sensor_msgs.msg import Range
@@ -163,7 +165,9 @@ def read_pings_messages(bag, start, end):
         m = deserialize_message(data, RawSonarImage)
         sv, rate = m.ping_info.sound_speed, m.sample_rate
         if rate > 0 and sv > 0 and m.samples_per_beam > 0:
-            rng = sv * m.samples_per_beam / (2.0 * rate)
+            # Full display range: sample0 is the omitted near-field head of the
+            # fixed grid, so the far edge sits at grid index sample0 + bins.
+            rng = sv * (m.sample0 + m.samples_per_beam) / (2.0 * rate)
         else:
             rng = None
             unscaled += 1
@@ -195,15 +199,15 @@ def read_pings_messages(bag, start, end):
     return chans
 
 
-def _bin_size(sub, n_samples, fallback):
-    """metres/sample from this channel's own display range (v2)."""
-    if sub and sub.display_range_m and n_samples:
-        return sub.display_range_m / n_samples
+def _bin_size(sub, fallback):
+    """metres/sample over the full GRID_BINS line, from this channel's v2 range."""
+    if sub and sub.display_range_m:
+        return sub.display_range_m / GRID_BINS
     return fallback
 
 
 def _median_bin(pings):
-    bs = [s.display_range_m / (len(samp) // 2)
+    bs = [s.display_range_m / GRID_BINS
           for _t, s, samp in pings if s and s.display_range_m and len(samp)]
     return float(np.median(bs)) if bs else 0.011
 
@@ -211,8 +215,14 @@ def _median_bin(pings):
 def _column(samp, sub, grid, fallback):
     """Resample a ping onto the metric grid -- RAW values, NaN beyond range."""
     a = np.frombuffer(samp, dtype='<u2').astype(float)
-    bs = _bin_size(sub, len(a), fallback)
-    return np.interp(grid / bs, np.arange(len(a)), a, right=np.nan)
+    bs = _bin_size(sub, fallback)
+    # The delivered samples are the gated TAIL of the GRID_BINS-sample line: the
+    # first (GRID_BINS - len(a)) grid samples are the omitted near-field, so
+    # delivered sample i sits at grid index (GRID_BINS - len(a)) + i. Map the
+    # metric grid back through that offset; the near-field strip is NaN (no data).
+    sample0 = GRID_BINS - len(a)
+    return np.interp(grid / bs - sample0, np.arange(len(a)), a,
+                     left=np.nan, right=np.nan)
 
 
 def _show_raw(ax, img, extent, cmap, vmin, vmax):

--- a/garmin_sidescan/tools/verify_range_scale.py
+++ b/garmin_sidescan/tools/verify_range_scale.py
@@ -118,7 +118,10 @@ def read_bag(bag, start, end):
         elif topic in img_topics and start <= rel <= end:
             m = deserialize_message(data, RawSonarImage)
             sv, rate = m.ping_info.sound_speed, m.sample_rate
-            rng = (sv * m.samples_per_beam / (2.0 * rate)
+            # Full display range = sv*(sample0 + bins)/(2*rate): sample0 is the
+            # near-field gate (the omitted head of the fixed grid), so the last
+            # delivered sample sits at grid index sample0 + samples_per_beam.
+            rng = (sv * (m.sample0 + m.samples_per_beam) / (2.0 * rate)
                    if rate > 0 and sv > 0 else float('nan'))
             published.setdefault(img_topics[topic], []).append((rel, rng))
         elif topic == state_topic and start <= rel <= end:


### PR DESCRIPTION
Closes #41.

Two changes to the `garmin_sidescan` driver, on one branch as separate commits.

## 1. Remove the sound-speed safety interlock

The GCV-10/20 stops pinging on its own when out of the water, so the dry-transducer watchdog is unnecessary. Removed the watchdog, transmit guard, auto-resume latch, dynamic master switch, the live sound-speed subscription, and ~10 parameters; dropped the now-unused `marine_interfaces` dependency. The node still asserts transmit OFF at startup and on shutdown and pings only on explicit command.

The sound-speed value is still needed as the constant that encodes the metric scale, so it's replaced by a single fixed **`sound_speed` parameter (default 1500 m/s)** — the device's *assumed* sound speed for scale reconstruction, stamped into `ping_info.sound_speed`.

## 2. Fix the near-field blanking in the range encoding

`_make_sonar_msg` hardcoded `sample0 = 0` and derived `sample_rate` from the delivered bin count, telling consumers the line spans range `0 → display_range`. It does not: the GCV frames each ping as a fixed **2048-sample grid** (`decode.GRID_BINS`) over `[0, display_range]` and delivers only the **last `n_bins`**, gating a ~0.1 m near-field zone at the start. The old encoding mis-located every sample, by **~20 % of range at short (~1.8 m) ranges**.

Now: `sample0 = max(0, 2048 − n_bins)` and `sample_rate = sv·2048/(2·display_range)`, so a consumer recovers delivered sample `j` at `range = sv·(sample0 + j)/(2·sample_rate)`. Validated against the device's own down-look bottom echo — it lands at the reported `bottom_range_m` only under this geometry (GCV-20; GCV-10 shows the same 2048 ceiling). Regression test pins the bottom-echo numbers (display_range 1.843 m, 1943 bins → sample0 105 → bottom ~0.381 m). In-repo tools (`verify_range_scale`, `sidescan_waterfall`) updated to add `sample0`.

## Review (pre-push, Standard depth, dual-lens adversarial)

Static analysis clean; 74 tests pass. Findings addressed:

- **Auto-stop premise** was asserted but uncited → provenance (field observation) + a bench-confirm TODO recorded in `docs/gcv_protocol.md` §4.6.
- **`transmit_on_startup` is now unguarded** against a dry transducer → README + param table warn to only energize with the transducer **submerged**. (Open question for reviewers: acceptable, or should startup keep a minimal guard?)

### Consequences / caveats

- ⚠️ **Breaking wire-contract change**: `sample0` is now nonzero. Out-of-repo `RawSonarImage` consumers (rqt sonar waterfall, CAMP) that assumed `sample0==0` will mis-locate samples until they add it. Tracked in #42.
- `ping_info.sound_speed` changed from a best-available measurement (0.0 when stale) to a fixed nominal 1500; a consumer doing its own SV correction must match this parameter.
- The transmit diagnostic dropped its "maybe-dry-transmitting" WARN (no SV source to evaluate).
- **TODO** (in `gcv_protocol.md` §4.6): bench-confirm the dry → transmit-stop latency.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
