### PR TITLE
kongsberg_em_bridge: option to save received datagrams to a .all file

### DIFF
--- a/.agent/work-plans/issue-46/progress.md
+++ b/.agent/work-plans/issue-46/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 46
+---
+
+# Issue #46 — kongsberg_em_bridge: option to save received datagrams to a .all file
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 23:14 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-46 at `2c66628`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~130-line feature touching driver recv/lifecycle)
+**Must-fix**: 1 (fixed before push) | **Suggestions**: 1 (declined, rationale below)
+
+### Findings
+- [x] (must-fix) Shutdown race: recv thread `_record` write vs `destroy_node` close of `self._save_file`; write-to-closed-file raises ValueError not caught by OSError-only handler — both adversarial lenses converged. Fixed with a `threading.Lock` guarding the None-check/write/close and by catching `(OSError, ValueError)` — `kongsberg_em_bridge/node.py`
+- [ ] (suggestion) Declined: flush-per-write under high datagram rate. `flush()` pushes to the OS page cache (not `fsync`), real M3 rates are a few hundred datagrams/s, and per-write flush preserves crash-safety of the recording — `kongsberg_em_bridge/node.py`
+
+### Notes
+- Static analysis: ament flake8 + pep257 clean via `colcon test` (13 tests, 0 failures).
+- Functional: node + `replay --all-types` produced a valid little-endian `.all` (0 non-STX records; A/G/N/X/C datagram types present; N/78 re-parses) and clean shutdown with no traceback.

--- a/kongsberg_em_bridge/kongsberg_em_bridge/em_datagrams.py
+++ b/kongsberg_em_bridge/kongsberg_em_bridge/em_datagrams.py
@@ -191,6 +191,24 @@ def parse_datagram(p: bytes) -> Optional[dict]:
     return {'type': dg}  # recognised but not decoded
 
 
+def frame_all_record(payload: bytes) -> bytes:
+    """
+    Frame one datagram payload as a record in a genuine Kongsberg ``.all`` file.
+
+    On-disk ``.all`` framing (EM Datagram Formats 850-160692): each datagram is
+    preceded by a 4-byte little-endian length giving the number of bytes in the
+    datagram -- i.e. STX through the checksum inclusive, which is exactly the
+    UDP payload as received. Files written this way load in Caris HIPS, QPS
+    Qimera, MB-System, etc.
+
+    This is deliberately NOT the framing used by :func:`iter_datagrams` /
+    ``replay`` (a *big-endian* length, the throwaway capture format from the
+    ``m3_udp_capture.py`` dev tool). Saved ``.all`` files are interoperable with
+    hydrographic software but are not replayable by the in-repo ``replay`` tool.
+    """
+    return struct.pack('<I', len(payload)) + payload
+
+
 def iter_datagrams(buf: bytes) -> Iterator[bytes]:
     """
     Yield raw datagram payloads from a length-framed capture file.

--- a/kongsberg_em_bridge/kongsberg_em_bridge/node.py
+++ b/kongsberg_em_bridge/kongsberg_em_bridge/node.py
@@ -14,7 +14,9 @@ downstream ``cube_bathymetry/detections_to_pointcloud`` node turns that into a
 TPU itself; it is purely a wire-format translator. See marine_tools#1.
 """
 
+import datetime
 import math
+import os
 import socket
 import struct
 import threading
@@ -40,12 +42,26 @@ class KongsbergEmBridge(Node):
         # iterates every element of two_way_travel_times and does NOT consult
         # flags, so invalid (twtt=0) beams would otherwise become z=0 points.
         self.declare_parameter('skip_invalid_beams', True)
+        # Directory in which to record the raw datagram stream as a genuine
+        # Kongsberg ``.all`` file (loadable by Caris/Qimera/MB-System). Empty
+        # disables recording. Each node run writes a fresh timestamped file so
+        # restarts never overwrite or interleave prior recordings.
+        self.declare_parameter('save_all_dir', '')
 
         self.frame_id = self.get_parameter('frame_id').value
         self.skip_invalid = bool(self.get_parameter('skip_invalid_beams').value)
 
         self.publisher = self.create_publisher(
             SonarDetections, 'detections', qos_profile_sensor_data)
+
+        self._save_file = self._open_save_file(
+            str(self.get_parameter('save_all_dir').value).strip())
+        self._save_count = 0
+        # Guards _save_file across the recv thread (_record) and the main
+        # thread (destroy_node). The thread join in destroy_node uses a
+        # timeout, so the recv thread can still be mid-write when shutdown
+        # closes the file -- the lock makes the None-check/write/close atomic.
+        self._save_lock = threading.Lock()
 
         addr = self.get_parameter('bind_address').value
         port = int(self.get_parameter('bind_port').value)
@@ -62,6 +78,52 @@ class KongsbergEmBridge(Node):
             f'kongsberg_em_bridge listening on {addr}:{port} (UDP), '
             f'publishing SonarDetections on "detections", frame "{self.frame_id}"')
 
+    def _open_save_file(self, save_dir):
+        """
+        Open a fresh timestamped ``.all`` file in ``save_dir``, or return None.
+
+        Returns the open binary file handle, or ``None`` if recording is
+        disabled (empty dir) or the file cannot be created -- a recording
+        failure must never stop the node from bridging live data.
+        """
+        if not save_dir:
+            return None
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+            '%Y%m%d_%H%M%S')
+        path = os.path.join(save_dir, f'm3_{stamp}.all')
+        try:
+            os.makedirs(save_dir, exist_ok=True)
+            handle = open(path, 'wb')
+        except OSError as exc:
+            self.get_logger().error(
+                f'could not open .all recording {path}: {exc}; '
+                f'continuing without recording')
+            return None
+        self.get_logger().info(f'recording received datagrams to {path}')
+        return handle
+
+    def _record(self, data):
+        """Append one received datagram to the ``.all`` file, if recording."""
+        with self._save_lock:
+            if self._save_file is None:
+                return
+            try:
+                self._save_file.write(em.frame_all_record(data))
+                self._save_file.flush()
+                self._save_count += 1
+            except (OSError, ValueError) as exc:
+                # Disable recording on write failure (e.g. disk full, or a
+                # write that lost the close/shutdown race -> "write to closed
+                # file" ValueError) rather than warn on every packet -- the
+                # live bridge must keep running.
+                self.get_logger().error(
+                    f'.all recording write failed: {exc}; recording disabled')
+                try:
+                    self._save_file.close()
+                except OSError:
+                    pass
+                self._save_file = None
+
     def destroy_node(self):
         self._running = False
         if self._thread.is_alive():
@@ -70,6 +132,15 @@ class KongsbergEmBridge(Node):
             self.sock.close()
         except OSError:
             pass
+        with self._save_lock:
+            if self._save_file is not None:
+                try:
+                    self._save_file.close()
+                except OSError:
+                    pass
+                self.get_logger().info(
+                    f'closed .all recording ({self._save_count} datagrams)')
+                self._save_file = None
         super().destroy_node()
 
     def _recv_loop(self):
@@ -80,6 +151,10 @@ class KongsbergEmBridge(Node):
                 continue
             except OSError:
                 break
+            # Record every received datagram (position, attitude, sound speed,
+            # clock, N/78, ...) before the N/78 publish filter, so the saved
+            # .all has the nav/attitude needed to georeference downstream.
+            self._record(data)
             if len(data) <= 1 or data[0] != em.STX or \
                     data[1] != em.DG_RAW_RANGE_ANGLE_78:
                 continue

--- a/kongsberg_em_bridge/launch/kongsberg_em_bridge.launch.py
+++ b/kongsberg_em_bridge/launch/kongsberg_em_bridge.launch.py
@@ -16,6 +16,10 @@ def generate_launch_description():
         DeclareLaunchArgument('bind_port', default_value='20002'),
         DeclareLaunchArgument('frame_id', default_value='m3'),
         DeclareLaunchArgument('namespace', default_value=''),
+        DeclareLaunchArgument(
+            'save_all_dir', default_value='',
+            description='Directory to record received datagrams as a timestamped '
+                        'Kongsberg .all file; empty disables recording.'),
         Node(
             package='kongsberg_em_bridge',
             executable='kongsberg_em_bridge',
@@ -24,6 +28,7 @@ def generate_launch_description():
             parameters=[{
                 'bind_port': LaunchConfiguration('bind_port'),
                 'frame_id': LaunchConfiguration('frame_id'),
+                'save_all_dir': LaunchConfiguration('save_all_dir'),
             }],
             output='screen',
         ),

--- a/kongsberg_em_bridge/test/test_em_datagrams.py
+++ b/kongsberg_em_bridge/test/test_em_datagrams.py
@@ -85,6 +85,40 @@ def test_dispatch_and_iter_framing():
     assert em.parse_datagram(payloads[1])['type'] == em.DG_ATTITUDE
 
 
+def test_frame_all_record_little_endian():
+    # Genuine .all framing is a little-endian length prefix == len(payload).
+    payload = bytes([em.STX, em.DG_ATTITUDE]) + b'\xaa\xbb\xcc'
+    rec = em.frame_all_record(payload)
+    assert rec == struct.pack('<I', len(payload)) + payload
+    assert struct.unpack_from('<I', rec, 0)[0] == len(payload)
+    assert rec[4:] == payload
+
+
+def test_frame_all_record_distinct_from_big_endian_capture():
+    # The saved .all length is little-endian and must differ from the repo's
+    # big-endian capture framing for any non-byte-symmetric length.
+    payload = b'\x02\x41' + b'\x00' * 258  # len 260 -> 0x0104, asymmetric
+    assert em.frame_all_record(payload)[:4] == struct.pack('<I', len(payload))
+    assert struct.pack('<I', len(payload)) != struct.pack('>I', len(payload))
+
+
+def test_frame_all_record_roundtrips_with_le_reader():
+    # A minimal little-endian reader recovers the original datagrams, proving
+    # the saved file is parseable as a real .all stream.
+    dg = _build_n78([(0.0, 0x00, 0.0125, -25.0)])
+    aux = bytes([em.STX, em.DG_POSITION]) + b'\x01\x02\x03'
+    blob = em.frame_all_record(dg) + em.frame_all_record(aux)
+    recovered = []
+    i = 0
+    while i + 4 <= len(blob):
+        (ln,) = struct.unpack_from('<I', blob, i)
+        i += 4
+        recovered.append(blob[i:i + ln])
+        i += ln
+    assert recovered == [dg, aux]
+    assert em.parse_datagram(recovered[0])['type'] == em.DG_RAW_RANGE_ANGLE_78
+
+
 def test_em_time_to_unix():
     assert em.em_time_to_unix(0, 0) is None
     assert em.em_time_to_unix(20260604, 86_400_000) is None  # time_ms out of range


### PR DESCRIPTION
## Summary

Adds a `save_all_dir` parameter to `kongsberg_em_bridge`. When set, the node
records the received Kongsberg EM datagram stream to a genuine Kongsberg `.all`
file on disk, so M3 survey data can be archived and re-processed in third-party
hydrographic software (Caris HIPS, QPS Qimera, MB-System). Empty (default) =
no recording, behaviour unchanged.

## What it does

- **`save_all_dir` param** — directory for recordings; each node run writes a
  fresh `<dir>/m3_<UTC YYYYMMDD_HHMMSS>.all` (no cross-run overwrite/append).
  Exposed as a launch argument too.
- **Saves every received datagram** (position, attitude, sound speed, clock,
  N/78, ...) — written before the N/78 publish filter, so the recording carries
  the nav/attitude needed to georeference downstream.
- **Genuine `.all` framing** — little-endian 4-byte length per datagram
  (`<I` = STX..checksum byte count), via new `em_datagrams.frame_all_record()`.
  Intentionally distinct from the repo's *big-endian* capture framing
  (`m3_udp_capture.py` / `iter_datagrams` / `replay`), which is left unchanged.
  Saved `.all` files are interoperable with hydro software but not replayable by
  the in-repo `replay` tool — see "Out of scope".
- **Field-robust** — a file-open or write error logs and disables recording
  rather than killing the recv thread or stopping the live bridge; the file is
  closed cleanly on shutdown. Recording state is guarded by a lock so the recv
  thread's writes and the shutdown close can't race.

## Testing

- `colcon test`: 13 tests, 0 failures (incl. ament flake8 + pep257). New unit
  tests cover the little-endian framing and a round-trip parse.
- Functional: ran the node with `save_all_dir` set and replayed a captured M3
  sample (`replay --all-types`). Output verified as a valid little-endian `.all`
  — 0 malformed records, datagram types A/G/N/X/C all present, N/78 re-parses.
  Clean shutdown, no traceback.

## Review

Pre-push `/review-code` (Standard, two disjoint-lens adversarial passes) flagged
a shutdown race between the recv thread's write and `destroy_node`'s file close
(write-to-closed-file raises `ValueError`, not caught by an `OSError`-only
handler). Fixed before push with a `threading.Lock` and by catching
`(OSError, ValueError)`. Timeline in `.agent/work-plans/issue-46/progress.md`.

## Out of scope

- Teaching `replay` / `iter_datagrams` to read little-endian `.all` (possible
  follow-up if in-repo replay of saved files is wanted).
- File rotation by size/line.

Closes #46. Part of #2.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
