### PR TITLE
bag_analysis: bag_to_xtf — convert recorded sidescan bags to XTF

### DIFF
--- a/.agent/work-plans/issue-45/progress.md
+++ b/.agent/work-plans/issue-45/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 45
+---
+
+# Issue #45 — bag_analysis: convert recorded Garmin sidescan bags to XTF
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 23:42 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (findings addressed)
+
+**Branch**: feature/issue-45 at `9f5bd12`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~960 lines new code, binary-format + geodesy correctness)
+**Must-fix**: 4 | **Suggestions**: 3
+
+### Findings
+- [x] (must-fix) Bounded the silent latest-TF fallback; drop+count stale pings — `cli/bag_to_xtf.py:_lookup_pose`
+- [x] (must-fix) Atomic output (.partial + rename) so a crash leaves no truncated XTF — `cli/bag_to_xtf.py:main`
+- [x] (must-fix) Exit non-zero when zero pings written — `cli/bag_to_xtf.py:main`
+- [x] (must-fix) Stop writing garbage per-ping Frequency uint16; CHANINFO float authoritative — `xtf/writer.py:_chan_header`
+- [x] (suggestion) Pair/timestamp/speed on header.stamp not bag-receive time — `cli/bag_to_xtf.py:_make_pending`
+- [x] (suggestion) Drop sample_rate<=0 pings as malformed — `cli/bag_to_xtf.py:_convert`
+- [x] (suggestion) Report per-cause drops + nadir-absent altitude warning — `cli/bag_to_xtf.py:_report`
+- [ ] (rejected) Write geodetic alt to SensorDepth — alt is ellipsoidal height, not depth-below-surface; SensorDepth=0 correct for surface mount

--- a/bag_analysis/README.md
+++ b/bag_analysis/README.md
@@ -124,11 +124,26 @@ from the latest `nadir_depth` (`sensor_msgs/Range`).
 frames** — a self-contained `bizzyboat_sonar` bag does; a sidescan-only
 `*_sidescan_raw` bag has no nav and cannot be georeferenced. The
 down-look channel is dropped (XTF is a two-channel port/starboard
-format). Key options: `--port-topic` / `--starboard-topic` /
-`--nadir-topic`, `--earth-frame` (default `earth`), `--pair-tolerance`
-(max |Δt| to pair port with starboard, default 0.25 s), and
-`--max-pings` (cap output, for quick checks). The converted samples are
-raw amplitudes, untouched by any artifact filtering.
+format). The converted samples are raw amplitudes, untouched by any
+artifact filtering.
+
+To trim dock idle from a survey, pass `--start-time` / `--end-time`
+(epoch seconds or an ISO-8601 UTC timestamp like
+`2026-06-15T16:26:49`); pings outside the window are skipped (TF is
+still consumed across the whole bag, so georeferencing is unaffected).
+A quick way to find the dock-out/dock-in times is the boat speed from
+`/bizzy/odom`. Example:
+
+```bash
+ros2 run bag_analysis bag_to_xtf --bag <bag> --output survey.xtf \
+    --start-time 2026-06-15T16:26:49 --end-time 2026-06-15T20:56:17
+```
+
+Other options: `--port-topic` / `--starboard-topic` / `--nadir-topic`,
+`--earth-frame` (default `earth`), `--pair-tolerance` (max |Δt| to pair
+port with starboard, default 0.25 s), `--max-tf-age` (drop pings whose
+only TF is older than this, default 1 s), and `--max-pings` (cap output,
+for quick checks).
 
 ## Schema
 

--- a/bag_analysis/README.md
+++ b/bag_analysis/README.md
@@ -97,6 +97,39 @@ than crashing the pipeline.
 `PlotResult` carries the PNG path plus a list of summary stats that
 land in `summary.md`.
 
+## Sidescan → XTF export (`bag_to_xtf`)
+
+`bag_to_xtf` converts recorded Garmin sidescan into an
+[XTF](https://en.wikipedia.org/wiki/EXtended_Triton_Format) file that
+standard survey tools read (OpenSideScan and MB-System on Linux;
+SonarWiz/Triton on Windows).
+
+```bash
+ros2 run bag_analysis bag_to_xtf \
+    --bag /path/to/bizzyboat_sonar/2026-06-15T15-03-45+00-00 \
+    --output ~/data/sidescan/2026-06-15.xtf
+```
+
+It reads the port and starboard `marine_acoustic_msgs/RawSonarImage`
+channels, pairs them per ping, and writes a two-channel (port/starboard)
+XTF. Each ping is georeferenced by composing the bag's TF tree offline
+and looking up `earth → <ping frame_id>`; since `earth` is the ECEF
+frame, that yields the transducer's true lat/lon plus heading/pitch/roll
+relative to local north. Slant range comes from the ping geometry
+(`(sample0 + n_samples) · sound_speed / (2 · sample_rate)`), so the
+near-field gate (`sample0`) is included. Altitude-above-bottom is taken
+from the latest `nadir_depth` (`sensor_msgs/Range`).
+
+**The bag must contain the full TF chain from `earth` to the sidescan
+frames** — a self-contained `bizzyboat_sonar` bag does; a sidescan-only
+`*_sidescan_raw` bag has no nav and cannot be georeferenced. The
+down-look channel is dropped (XTF is a two-channel port/starboard
+format). Key options: `--port-topic` / `--starboard-topic` /
+`--nadir-topic`, `--earth-frame` (default `earth`), `--pair-tolerance`
+(max |Δt| to pair port with starboard, default 0.25 s), and
+`--max-pings` (cap output, for quick checks). The converted samples are
+raw amplitudes, untouched by any artifact filtering.
+
 ## Schema
 
 `data.db` holds:

--- a/bag_analysis/bag_analysis/cli/bag_to_xtf.py
+++ b/bag_analysis/bag_analysis/cli/bag_to_xtf.py
@@ -1,0 +1,278 @@
+r"""
+CLI: convert recorded sidescan from a rosbag2 to an XTF file.
+
+Reads ``marine_acoustic_msgs/RawSonarImage`` port and starboard channels
+plus the TF tree, georeferences each ping via an ``earth`` (ECEF) frame
+lookup of the ping's own ``header.frame_id``, pairs port with starboard,
+and streams two-channel XTF ping packets to disk.
+
+Usage::
+
+    ros2 run bag_analysis bag_to_xtf \\
+        --bag /path/to/bizzyboat_sonar/2026-06-15T15-03-45+00-00 \\
+        --output ~/data/sidescan/2026-06-15.xtf
+
+The bag must contain the TF chain from ``earth`` down to the sidescan
+sensor frames (a self-contained ``bizzyboat_sonar`` bag does); a
+sidescan-only ``*_sidescan_raw`` bag has no nav and cannot be
+georeferenced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+from pathlib import Path
+import sys
+
+import numpy as np
+from rclpy.duration import Duration
+import rclpy.time
+from tf2_ros import Buffer, TransformException
+
+from ..reader import iter_messages
+from ..xtf.geo import ecef_pose_to_geo
+from ..xtf.writer import ChannelPing, XtfWriter
+
+# marine_acoustic_msgs/SonarImageData.dtype -> (numpy base type, is_signed).
+_DTYPE_MAP = {
+    0: np.uint8, 1: np.int8, 2: np.uint16, 3: np.int16,
+    4: np.uint32, 5: np.int32, 6: np.uint64, 7: np.int64,
+    8: np.float32, 9: np.float64,
+}
+
+_DEFAULT_PORT = '/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_port'
+_DEFAULT_STBD = '/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_starboard'
+_DEFAULT_NADIR = '/bizzy/sensors/sidescan/garmin_sidescan/nadir_depth'
+_DEFAULT_SOUND_SPEED = 1500.0
+
+
+class _PendingPing:
+    """A georeferenced single-channel ping awaiting its counterpart."""
+
+    __slots__ = (
+        't_ns', 'time', 'lat', 'lon', 'alt', 'heading', 'pitch', 'roll',
+        'ecef', 'samples', 'slant_range', 'frequency', 'time_delay',
+        'time_duration', 'sound_velocity',
+    )
+
+    def __init__(self, **kw) -> None:
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog='bag_to_xtf',
+        description='Convert recorded sidescan from a rosbag2 to XTF.',
+    )
+    p.add_argument(
+        '--bag', required=True, type=Path,
+        help='Path to the rosbag2 directory (the one with metadata.yaml)',
+    )
+    p.add_argument(
+        '--output', required=True, type=Path,
+        help='Output XTF file path (e.g. .../survey.xtf)',
+    )
+    p.add_argument('--port-topic', default=_DEFAULT_PORT)
+    p.add_argument('--starboard-topic', default=_DEFAULT_STBD)
+    p.add_argument(
+        '--nadir-topic', default=_DEFAULT_NADIR,
+        help='sensor_msgs/Range topic used for altitude-above-bottom',
+    )
+    p.add_argument(
+        '--earth-frame', default='earth',
+        help='ECEF root frame for georeferencing (default: earth)',
+    )
+    p.add_argument(
+        '--pair-tolerance', type=float, default=0.25,
+        help='Max |dt| (s) to pair a port ping with a starboard ping',
+    )
+    p.add_argument(
+        '--tf-cache', type=float, default=600.0,
+        help='TF buffer cache length in seconds',
+    )
+    p.add_argument(
+        '--sonar-name', default='Garmin GCV sidescan',
+        help='SonarName written to the XTF file header',
+    )
+    p.add_argument(
+        '--max-pings', type=int, default=None,
+        help='Stop after writing this many ping packets (for testing)',
+    )
+    return p
+
+
+def _decode_samples(msg) -> np.ndarray:
+    """Decode a RawSonarImage image payload to a 1-D float array."""
+    base = _DTYPE_MAP.get(msg.image.dtype, np.uint8)
+    dtype = np.dtype(base).newbyteorder('>' if msg.image.is_bigendian else '<')
+    arr = np.frombuffer(bytes(msg.image.data), dtype=dtype).astype(np.float64)
+    beams = max(int(msg.image.beam_count), 1)
+    if beams > 1 and arr.size % beams == 0:
+        arr = arr.reshape(-1, beams).mean(axis=1)
+    return arr
+
+
+def _ping_geometry(msg, n_samples: int) -> tuple[float, float, float, float]:
+    """Return (slant_range_m, time_delay_s, time_duration_s, sound_speed)."""
+    sound_speed = msg.ping_info.sound_speed or _DEFAULT_SOUND_SPEED
+    fs = float(msg.sample_rate)
+    if fs <= 0.0:
+        return 0.0, 0.0, 0.0, sound_speed
+    sample0 = int(msg.sample0)
+    # Range to the last sample; the near-field gate (sample0) shifts the
+    # window away from the transducer, so it must be included.
+    slant_range = (sample0 + n_samples) * sound_speed / (2.0 * fs)
+    time_delay = sample0 / fs            # round-trip time to first sample
+    time_duration = n_samples / fs
+    return slant_range, time_delay, time_duration, sound_speed
+
+
+def _lookup_pose(buffer: Buffer, frame: str, earth_frame: str, stamp):
+    """
+    Look up earth->frame, preferring the ping stamp, falling back to latest.
+
+    Returns (translation_xyz, quaternion_xyzw) or None if unavailable.
+    """
+    for query_time in (rclpy.time.Time.from_msg(stamp), rclpy.time.Time()):
+        try:
+            tf = buffer.lookup_transform(earth_frame, frame, query_time)
+        except TransformException:
+            continue
+        t = tf.transform.translation
+        q = tf.transform.rotation
+        return (t.x, t.y, t.z), (q.x, q.y, q.z, q.w)
+    return None
+
+
+def _make_pending(msg, t_ns, pose, altitude) -> _PendingPing:
+    samples = _decode_samples(msg)
+    slant_range, time_delay, time_duration, sound_speed = _ping_geometry(
+        msg, samples.size)
+    lat, lon, alt, heading, pitch, roll = ecef_pose_to_geo(pose[0], pose[1])
+    return _PendingPing(
+        t_ns=t_ns,
+        time=_dt.datetime.fromtimestamp(t_ns / 1e9, tz=_dt.timezone.utc),
+        lat=lat, lon=lon, alt=alt, heading=heading, pitch=pitch, roll=roll,
+        ecef=np.array(pose[0]), samples=samples, slant_range=slant_range,
+        frequency=msg.ping_info.frequency, time_delay=time_delay,
+        time_duration=time_duration, sound_velocity=sound_speed,
+    )
+
+
+def _speed_mps(a: _PendingPing, b: _PendingPing) -> float:
+    """Ground speed between two pings from their ECEF displacement."""
+    dt = abs(a.t_ns - b.t_ns) / 1e9
+    if dt <= 0.0:
+        return 0.0
+    return float(np.linalg.norm(a.ecef - b.ecef) / dt)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``bag_to_xtf`` console script."""
+    args = _build_parser().parse_args(argv)
+    if not args.bag.exists():
+        print(f'error: bag not found: {args.bag}', file=sys.stderr)
+        return 2
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    buffer = Buffer(cache_time=Duration(seconds=args.tf_cache))
+    topics = [
+        '/tf', '/tf_static', args.port_topic, args.starboard_topic,
+        args.nadir_topic,
+    ]
+
+    pending: dict[str, _PendingPing] = {'port': None, 'starboard': None}
+    latest_altitude = 0.0
+    prev_emitted: _PendingPing | None = None
+    counts = {'port': 0, 'starboard': 0, 'paired': 0,
+              'no_tf': 0, 'unpaired': 0}
+
+    with open(args.output, 'wb') as stream:
+        writer = XtfWriter(stream, sonar_name=args.sonar_name)
+
+        def emit(port: _PendingPing, stbd: _PendingPing) -> None:
+            nonlocal prev_emitted
+            speed = _speed_mps(prev_emitted, port) if prev_emitted else 0.0
+            writer.write_ping(
+                time=port.time,
+                ping_number=writer.ping_count,
+                latitude_deg=port.lat, longitude_deg=port.lon,
+                sensor_depth_m=0.0, altitude_m=latest_altitude,
+                heading_deg=port.heading, pitch_deg=port.pitch,
+                roll_deg=port.roll, speed_mps=speed,
+                sound_velocity_mps=port.sound_velocity,
+                port=ChannelPing(
+                    samples=port.samples, slant_range_m=port.slant_range,
+                    frequency_hz=port.frequency,
+                    time_delay_s=port.time_delay,
+                    time_duration_s=port.time_duration),
+                starboard=ChannelPing(
+                    samples=stbd.samples, slant_range_m=stbd.slant_range,
+                    frequency_hz=stbd.frequency,
+                    time_delay_s=stbd.time_delay,
+                    time_duration_s=stbd.time_duration),
+            )
+            counts['paired'] += 1
+            prev_emitted = port
+
+        for topic, msg, t_ns in iter_messages(args.bag, topics=topics):
+            if topic == '/tf':
+                for tr in msg.transforms:
+                    buffer.set_transform(tr, 'bag_to_xtf')
+                continue
+            if topic == '/tf_static':
+                for tr in msg.transforms:
+                    buffer.set_transform_static(tr, 'bag_to_xtf')
+                continue
+            if topic == args.nadir_topic:
+                latest_altitude = float(msg.range)
+                continue
+
+            if topic == args.port_topic:
+                side = 'port'
+            elif topic == args.starboard_topic:
+                side = 'starboard'
+            else:
+                continue
+            counts[side] += 1
+
+            pose = _lookup_pose(
+                buffer, msg.header.frame_id, args.earth_frame,
+                msg.header.stamp)
+            if pose is None:
+                counts['no_tf'] += 1
+                continue
+            ping = _make_pending(msg, t_ns, pose, latest_altitude)
+
+            other = 'starboard' if side == 'port' else 'port'
+            mate = pending[other]
+            if mate is not None and abs(ping.t_ns - mate.t_ns) <= (
+                    args.pair_tolerance * 1e9):
+                port, stbd = (ping, mate) if side == 'port' else (mate, ping)
+                emit(port, stbd)
+                pending['port'] = pending['starboard'] = None
+            else:
+                if pending[side] is not None:
+                    counts['unpaired'] += 1
+                pending[side] = ping
+
+            if args.max_pings is not None and \
+                    writer.ping_count >= args.max_pings:
+                break
+
+    counts['unpaired'] += sum(1 for v in pending.values() if v is not None)
+    _report(args.output, writer.ping_count, counts)
+    return 0
+
+
+def _report(output: Path, ping_count: int, counts: dict[str, int]) -> None:
+    print(f'wrote {ping_count} XTF pings -> {output}')
+    print(f'  port msgs={counts["port"]} starboard msgs={counts["starboard"]}')
+    print(f'  paired={counts["paired"]} '
+          f'dropped_no_tf={counts["no_tf"]} unpaired={counts["unpaired"]}')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bag_analysis/bag_analysis/cli/bag_to_xtf.py
+++ b/bag_analysis/bag_analysis/cli/bag_to_xtf.py
@@ -16,6 +16,11 @@ The bag must contain the TF chain from ``earth`` down to the sidescan
 sensor frames (a self-contained ``bizzyboat_sonar`` bag does); a
 sidescan-only ``*_sidescan_raw`` bag has no nav and cannot be
 georeferenced.
+
+The output is written to a ``.partial`` sibling and atomically renamed
+into place only after a clean run, so a crash mid-stream never leaves a
+truncated-but-valid-looking XTF behind. A run that writes zero pings
+(wrong topics, no nav, all-malformed) exits non-zero.
 """
 
 from __future__ import annotations
@@ -34,7 +39,7 @@ from ..reader import iter_messages
 from ..xtf.geo import ecef_pose_to_geo
 from ..xtf.writer import ChannelPing, XtfWriter
 
-# marine_acoustic_msgs/SonarImageData.dtype -> (numpy base type, is_signed).
+# marine_acoustic_msgs/SonarImageData.dtype -> numpy base type.
 _DTYPE_MAP = {
     0: np.uint8, 1: np.int8, 2: np.uint16, 3: np.int16,
     4: np.uint32, 5: np.int32, 6: np.uint64, 7: np.int64,
@@ -45,18 +50,20 @@ _DEFAULT_PORT = '/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_port'
 _DEFAULT_STBD = '/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_starboard'
 _DEFAULT_NADIR = '/bizzy/sensors/sidescan/garmin_sidescan/nadir_depth'
 _DEFAULT_SOUND_SPEED = 1500.0
+_NS_PER_S = 1_000_000_000
 
 
 class _PendingPing:
     """A georeferenced single-channel ping awaiting its counterpart."""
 
     __slots__ = (
-        't_ns', 'time', 'lat', 'lon', 'alt', 'heading', 'pitch', 'roll',
+        't_ns', 'time', 'lat', 'lon', 'heading', 'pitch', 'roll',
         'ecef', 'samples', 'slant_range', 'frequency', 'time_delay',
         'time_duration', 'sound_velocity',
     )
 
     def __init__(self, **kw) -> None:
+        """Populate slots from keyword arguments."""
         for k, v in kw.items():
             setattr(self, k, v)
 
@@ -86,7 +93,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         '--pair-tolerance', type=float, default=0.25,
-        help='Max |dt| (s) to pair a port ping with a starboard ping',
+        help='Max |dt| (s) on header stamps to pair port with starboard',
+    )
+    p.add_argument(
+        '--max-tf-age', type=float, default=1.0,
+        help=('Max age (s) of a fallback "latest" TF relative to the ping '
+              'stamp before the ping is dropped as un-georeferenceable'),
     )
     p.add_argument(
         '--tf-cache', type=float, default=600.0,
@@ -118,8 +130,6 @@ def _ping_geometry(msg, n_samples: int) -> tuple[float, float, float, float]:
     """Return (slant_range_m, time_delay_s, time_duration_s, sound_speed)."""
     sound_speed = msg.ping_info.sound_speed or _DEFAULT_SOUND_SPEED
     fs = float(msg.sample_rate)
-    if fs <= 0.0:
-        return 0.0, 0.0, 0.0, sound_speed
     sample0 = int(msg.sample0)
     # Range to the last sample; the near-field gate (sample0) shifts the
     # window away from the transducer, so it must be included.
@@ -129,32 +139,60 @@ def _ping_geometry(msg, n_samples: int) -> tuple[float, float, float, float]:
     return slant_range, time_delay, time_duration, sound_speed
 
 
-def _lookup_pose(buffer: Buffer, frame: str, earth_frame: str, stamp):
+def _stamp_ns(stamp) -> int:
+    """Nanoseconds since epoch from a builtin_interfaces/Time stamp."""
+    return stamp.sec * _NS_PER_S + stamp.nanosec
+
+
+def _lookup_pose(buffer, frame, earth_frame, stamp, max_tf_age_ns):
     """
-    Look up earth->frame, preferring the ping stamp, falling back to latest.
+    Look up earth->frame at the ping stamp, with a bounded latest fallback.
 
-    Returns (translation_xyz, quaternion_xyzw) or None if unavailable.
+    Returns ``(pose, status)`` where ``pose`` is
+    ``((x, y, z), (qx, qy, qz, qw))`` or ``None``, and ``status`` is one
+    of ``'exact'`` (stamped lookup), ``'approx'`` (fell back to the
+    latest transform, within ``max_tf_age_ns``), ``'stale'`` (latest
+    transform too old -> dropped), or ``'missing'`` (no transform at
+    all). A bounded fallback prevents silently stamping a ping with a
+    pose from an unrelated time when TF has a gap.
     """
-    for query_time in (rclpy.time.Time.from_msg(stamp), rclpy.time.Time()):
-        try:
-            tf = buffer.lookup_transform(earth_frame, frame, query_time)
-        except TransformException:
-            continue
-        t = tf.transform.translation
-        q = tf.transform.rotation
-        return (t.x, t.y, t.z), (q.x, q.y, q.z, q.w)
-    return None
+    try:
+        tf = buffer.lookup_transform(
+            earth_frame, frame, rclpy.time.Time.from_msg(stamp))
+        return _pose_from_tf(tf), 'exact'
+    except TransformException:
+        pass
+    try:
+        tf = buffer.lookup_transform(earth_frame, frame, rclpy.time.Time())
+    except TransformException:
+        return None, 'missing'
+    ping_ns = _stamp_ns(stamp)
+    age = abs(ping_ns - _stamp_ns(tf.header.stamp))
+    if ping_ns > 0 and age > max_tf_age_ns:
+        return None, 'stale'
+    return _pose_from_tf(tf), 'approx'
 
 
-def _make_pending(msg, t_ns, pose, altitude) -> _PendingPing:
+def _pose_from_tf(tf):
+    """Extract ((x, y, z), (qx, qy, qz, qw)) from a TransformStamped."""
+    t = tf.transform.translation
+    q = tf.transform.rotation
+    return (t.x, t.y, t.z), (q.x, q.y, q.z, q.w)
+
+
+def _make_pending(msg, bag_t_ns, pose) -> _PendingPing:
+    """Build a georeferenced pending ping from a RawSonarImage + TF pose."""
     samples = _decode_samples(msg)
     slant_range, time_delay, time_duration, sound_speed = _ping_geometry(
         msg, samples.size)
-    lat, lon, alt, heading, pitch, roll = ecef_pose_to_geo(pose[0], pose[1])
+    lat, lon, _alt, heading, pitch, roll = ecef_pose_to_geo(pose[0], pose[1])
+    # Prefer the acquisition stamp; fall back to bag-receive time only if
+    # the driver left the header unstamped.
+    stamp_ns = _stamp_ns(msg.header.stamp) or bag_t_ns
     return _PendingPing(
-        t_ns=t_ns,
-        time=_dt.datetime.fromtimestamp(t_ns / 1e9, tz=_dt.timezone.utc),
-        lat=lat, lon=lon, alt=alt, heading=heading, pitch=pitch, roll=roll,
+        t_ns=stamp_ns,
+        time=_dt.datetime.fromtimestamp(stamp_ns / 1e9, tz=_dt.timezone.utc),
+        lat=lat, lon=lon, heading=heading, pitch=pitch, roll=roll,
         ecef=np.array(pose[0]), samples=samples, slant_range=slant_range,
         frequency=msg.ping_info.frequency, time_delay=time_delay,
         time_duration=time_duration, sound_velocity=sound_speed,
@@ -169,6 +207,99 @@ def _speed_mps(a: _PendingPing, b: _PendingPing) -> float:
     return float(np.linalg.norm(a.ecef - b.ecef) / dt)
 
 
+def _convert(args, stream, counts) -> int:
+    """Run the read/georeference/pair/write loop; return pings written."""
+    buffer = Buffer(cache_time=Duration(seconds=args.tf_cache))
+    topics = [
+        '/tf', '/tf_static', args.port_topic, args.starboard_topic,
+        args.nadir_topic,
+    ]
+    max_tf_age_ns = int(args.max_tf_age * _NS_PER_S)
+    pair_tol_ns = args.pair_tolerance * _NS_PER_S
+
+    writer = XtfWriter(stream, sonar_name=args.sonar_name)
+    pending: dict = {'port': None, 'starboard': None}
+    latest_altitude = None
+    prev_emitted = None
+
+    def emit(port: _PendingPing, stbd: _PendingPing) -> None:
+        nonlocal prev_emitted
+        speed = _speed_mps(prev_emitted, port) if prev_emitted else 0.0
+        if latest_altitude is None:
+            counts['no_altitude'] += 1
+        writer.write_ping(
+            time=port.time, ping_number=writer.ping_count,
+            latitude_deg=port.lat, longitude_deg=port.lon,
+            sensor_depth_m=0.0, altitude_m=latest_altitude or 0.0,
+            heading_deg=port.heading, pitch_deg=port.pitch,
+            roll_deg=port.roll, speed_mps=speed,
+            sound_velocity_mps=port.sound_velocity,
+            port=ChannelPing(
+                samples=port.samples, slant_range_m=port.slant_range,
+                frequency_hz=port.frequency, time_delay_s=port.time_delay,
+                time_duration_s=port.time_duration),
+            starboard=ChannelPing(
+                samples=stbd.samples, slant_range_m=stbd.slant_range,
+                frequency_hz=stbd.frequency, time_delay_s=stbd.time_delay,
+                time_duration_s=stbd.time_duration),
+        )
+        counts['paired'] += 1
+        prev_emitted = port
+
+    for topic, msg, t_ns in iter_messages(args.bag, topics=topics):
+        if topic == '/tf':
+            for tr in msg.transforms:
+                buffer.set_transform(tr, 'bag_to_xtf')
+            continue
+        if topic == '/tf_static':
+            for tr in msg.transforms:
+                buffer.set_transform_static(tr, 'bag_to_xtf')
+            continue
+        if topic == args.nadir_topic:
+            latest_altitude = float(msg.range)
+            counts['nadir'] += 1
+            continue
+
+        if topic == args.port_topic:
+            side = 'port'
+        elif topic == args.starboard_topic:
+            side = 'starboard'
+        else:
+            continue
+        counts[side] += 1
+
+        if float(msg.sample_rate) <= 0.0:
+            counts['malformed'] += 1
+            continue
+
+        pose, status = _lookup_pose(
+            buffer, msg.header.frame_id, args.earth_frame,
+            msg.header.stamp, max_tf_age_ns)
+        if pose is None:
+            counts['no_tf' if status == 'missing' else 'stale_tf'] += 1
+            continue
+        if status == 'approx':
+            counts['approx_tf'] += 1
+        ping = _make_pending(msg, t_ns, pose)
+
+        other = 'starboard' if side == 'port' else 'port'
+        mate = pending[other]
+        if mate is not None and abs(ping.t_ns - mate.t_ns) <= pair_tol_ns:
+            port, stbd = (ping, mate) if side == 'port' else (mate, ping)
+            emit(port, stbd)
+            pending['port'] = pending['starboard'] = None
+        else:
+            if pending[side] is not None:
+                counts['unpaired'] += 1  # discarded; mate never arrived
+            pending[side] = ping
+
+        if args.max_pings is not None and writer.ping_count >= args.max_pings:
+            break
+
+    counts['unpaired'] += sum(1 for v in pending.values() if v is not None)
+    return writer.ping_count
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``bag_to_xtf`` console script."""
     args = _build_parser().parse_args(argv)
@@ -177,101 +308,49 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     args.output.parent.mkdir(parents=True, exist_ok=True)
 
-    buffer = Buffer(cache_time=Duration(seconds=args.tf_cache))
-    topics = [
-        '/tf', '/tf_static', args.port_topic, args.starboard_topic,
-        args.nadir_topic,
-    ]
+    counts = {
+        'port': 0, 'starboard': 0, 'paired': 0, 'no_tf': 0, 'stale_tf': 0,
+        'approx_tf': 0, 'malformed': 0, 'unpaired': 0, 'nadir': 0,
+        'no_altitude': 0,
+    }
+    # Write to a sibling .partial and rename on success, so a crash never
+    # leaves a truncated file at the destination path.
+    partial = args.output.with_name(args.output.name + '.partial')
+    try:
+        with open(partial, 'wb') as stream:
+            ping_count = _convert(args, stream, counts)
+    except BaseException:
+        partial.unlink(missing_ok=True)
+        raise
 
-    pending: dict[str, _PendingPing] = {'port': None, 'starboard': None}
-    latest_altitude = 0.0
-    prev_emitted: _PendingPing | None = None
-    counts = {'port': 0, 'starboard': 0, 'paired': 0,
-              'no_tf': 0, 'unpaired': 0}
+    if ping_count == 0:
+        partial.unlink(missing_ok=True)
+        print('error: no pings written (check topics, nav/TF, sample_rate)',
+              file=sys.stderr)
+        _report(args.output, ping_count, counts)
+        return 1
 
-    with open(args.output, 'wb') as stream:
-        writer = XtfWriter(stream, sonar_name=args.sonar_name)
-
-        def emit(port: _PendingPing, stbd: _PendingPing) -> None:
-            nonlocal prev_emitted
-            speed = _speed_mps(prev_emitted, port) if prev_emitted else 0.0
-            writer.write_ping(
-                time=port.time,
-                ping_number=writer.ping_count,
-                latitude_deg=port.lat, longitude_deg=port.lon,
-                sensor_depth_m=0.0, altitude_m=latest_altitude,
-                heading_deg=port.heading, pitch_deg=port.pitch,
-                roll_deg=port.roll, speed_mps=speed,
-                sound_velocity_mps=port.sound_velocity,
-                port=ChannelPing(
-                    samples=port.samples, slant_range_m=port.slant_range,
-                    frequency_hz=port.frequency,
-                    time_delay_s=port.time_delay,
-                    time_duration_s=port.time_duration),
-                starboard=ChannelPing(
-                    samples=stbd.samples, slant_range_m=stbd.slant_range,
-                    frequency_hz=stbd.frequency,
-                    time_delay_s=stbd.time_delay,
-                    time_duration_s=stbd.time_duration),
-            )
-            counts['paired'] += 1
-            prev_emitted = port
-
-        for topic, msg, t_ns in iter_messages(args.bag, topics=topics):
-            if topic == '/tf':
-                for tr in msg.transforms:
-                    buffer.set_transform(tr, 'bag_to_xtf')
-                continue
-            if topic == '/tf_static':
-                for tr in msg.transforms:
-                    buffer.set_transform_static(tr, 'bag_to_xtf')
-                continue
-            if topic == args.nadir_topic:
-                latest_altitude = float(msg.range)
-                continue
-
-            if topic == args.port_topic:
-                side = 'port'
-            elif topic == args.starboard_topic:
-                side = 'starboard'
-            else:
-                continue
-            counts[side] += 1
-
-            pose = _lookup_pose(
-                buffer, msg.header.frame_id, args.earth_frame,
-                msg.header.stamp)
-            if pose is None:
-                counts['no_tf'] += 1
-                continue
-            ping = _make_pending(msg, t_ns, pose, latest_altitude)
-
-            other = 'starboard' if side == 'port' else 'port'
-            mate = pending[other]
-            if mate is not None and abs(ping.t_ns - mate.t_ns) <= (
-                    args.pair_tolerance * 1e9):
-                port, stbd = (ping, mate) if side == 'port' else (mate, ping)
-                emit(port, stbd)
-                pending['port'] = pending['starboard'] = None
-            else:
-                if pending[side] is not None:
-                    counts['unpaired'] += 1
-                pending[side] = ping
-
-            if args.max_pings is not None and \
-                    writer.ping_count >= args.max_pings:
-                break
-
-    counts['unpaired'] += sum(1 for v in pending.values() if v is not None)
-    _report(args.output, writer.ping_count, counts)
+    partial.replace(args.output)
+    _report(args.output, ping_count, counts)
     return 0
 
 
-def _report(output: Path, ping_count: int, counts: dict[str, int]) -> None:
+def _report(output: Path, ping_count: int, counts: dict) -> None:
+    """Print a conversion summary, including any data loss."""
     print(f'wrote {ping_count} XTF pings -> {output}')
-    print(f'  port msgs={counts["port"]} starboard msgs={counts["starboard"]}')
-    print(f'  paired={counts["paired"]} '
-          f'dropped_no_tf={counts["no_tf"]} unpaired={counts["unpaired"]}')
+    print(f'  port msgs={counts["port"]} starboard msgs={counts["starboard"]}'
+          f' paired={counts["paired"]}')
+    print(f'  dropped: no_tf={counts["no_tf"]} stale_tf={counts["stale_tf"]} '
+          f'malformed={counts["malformed"]} unpaired={counts["unpaired"]}')
+    if counts['approx_tf']:
+        print(f'  note: {counts["approx_tf"]} pings used a latest-TF fallback '
+              '(within --max-tf-age)')
+    if counts['nadir'] == 0:
+        print('  warning: no nadir_depth messages; altitude written as 0 for '
+              'all pings')
+    elif counts['no_altitude']:
+        print(f'  warning: {counts["no_altitude"]} pings written before the '
+              'first nadir_depth (altitude 0)')
 
 
 if __name__ == '__main__':

--- a/bag_analysis/bag_analysis/cli/bag_to_xtf.py
+++ b/bag_analysis/bag_analysis/cli/bag_to_xtf.py
@@ -101,6 +101,16 @@ def _build_parser() -> argparse.ArgumentParser:
               'stamp before the ping is dropped as un-georeferenceable'),
     )
     p.add_argument(
+        '--start-time', default=None,
+        help=('Skip pings before this time. Accepts epoch seconds or an '
+              'ISO-8601 UTC timestamp (e.g. 2026-06-15T16:26:49). Use to '
+              'trim dock idle from the start of a survey.'),
+    )
+    p.add_argument(
+        '--end-time', default=None,
+        help='Skip pings after this time (same formats as --start-time).',
+    )
+    p.add_argument(
         '--tf-cache', type=float, default=600.0,
         help='TF buffer cache length in seconds',
     )
@@ -142,6 +152,26 @@ def _ping_geometry(msg, n_samples: int) -> tuple[float, float, float, float]:
 def _stamp_ns(stamp) -> int:
     """Nanoseconds since epoch from a builtin_interfaces/Time stamp."""
     return stamp.sec * _NS_PER_S + stamp.nanosec
+
+
+def _parse_time(value):
+    """
+    Parse a CLI time to epoch nanoseconds, or None if not given.
+
+    Accepts either epoch seconds (e.g. ``1750000000``) or an ISO-8601
+    timestamp (e.g. ``2026-06-15T16:26:49``); a naive ISO time is read
+    as UTC.
+    """
+    if value is None:
+        return None
+    try:
+        return int(float(value) * 1e9)
+    except ValueError:
+        pass
+    parsed = _dt.datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return int(parsed.timestamp() * 1e9)
 
 
 def _lookup_pose(buffer, frame, earth_frame, stamp, max_tf_age_ns):
@@ -216,6 +246,8 @@ def _convert(args, stream, counts) -> int:
     ]
     max_tf_age_ns = int(args.max_tf_age * _NS_PER_S)
     pair_tol_ns = args.pair_tolerance * _NS_PER_S
+    start_ns = _parse_time(args.start_time)
+    end_ns = _parse_time(args.end_time)
 
     writer = XtfWriter(stream, sonar_name=args.sonar_name)
     pending: dict = {'port': None, 'starboard': None}
@@ -268,6 +300,16 @@ def _convert(args, stream, counts) -> int:
             continue
         counts[side] += 1
 
+        # Time-window trim (e.g. dock-out to dock-in). TF/nadir are fed
+        # regardless above; only sidescan pings are gated. The bag is
+        # time-ordered, so once past end_ns nothing more is needed.
+        eff_ns = _stamp_ns(msg.header.stamp) or t_ns
+        if start_ns is not None and eff_ns < start_ns:
+            counts['out_of_window'] += 1
+            continue
+        if end_ns is not None and eff_ns > end_ns:
+            break
+
         if float(msg.sample_rate) <= 0.0:
             counts['malformed'] += 1
             continue
@@ -311,7 +353,7 @@ def main(argv: list[str] | None = None) -> int:
     counts = {
         'port': 0, 'starboard': 0, 'paired': 0, 'no_tf': 0, 'stale_tf': 0,
         'approx_tf': 0, 'malformed': 0, 'unpaired': 0, 'nadir': 0,
-        'no_altitude': 0,
+        'no_altitude': 0, 'out_of_window': 0,
     }
     # Write to a sibling .partial and rename on success, so a crash never
     # leaves a truncated file at the destination path.
@@ -342,6 +384,9 @@ def _report(output: Path, ping_count: int, counts: dict) -> None:
           f' paired={counts["paired"]}')
     print(f'  dropped: no_tf={counts["no_tf"]} stale_tf={counts["stale_tf"]} '
           f'malformed={counts["malformed"]} unpaired={counts["unpaired"]}')
+    if counts['out_of_window']:
+        print(f'  trimmed: {counts["out_of_window"]} pings outside '
+              '--start-time/--end-time window')
     if counts['approx_tf']:
         print(f'  note: {counts["approx_tf"]} pings used a latest-TF fallback '
               '(within --max-tf-age)')

--- a/bag_analysis/bag_analysis/xtf/__init__.py
+++ b/bag_analysis/bag_analysis/xtf/__init__.py
@@ -1,0 +1,12 @@
+"""
+XTF (eXtended Triton Format) export for recorded sidescan bags.
+
+Submodules:
+
+* :mod:`bag_analysis.xtf.geo` -- WGS84 ECEF <-> geodetic conversion and
+  ECEF orientation -> local (NED) heading/pitch/roll extraction, used to
+  turn a ``earth`` (ECEF) frame TF lookup into the lat/lon and attitude
+  an XTF ping header needs.
+* :mod:`bag_analysis.xtf.writer` -- a streaming binary writer for the
+  XTF file header, channel-info blocks, and per-ping packets.
+"""

--- a/bag_analysis/bag_analysis/xtf/geo.py
+++ b/bag_analysis/bag_analysis/xtf/geo.py
@@ -1,0 +1,165 @@
+"""
+WGS84 geodesy helpers for the XTF exporter.
+
+Turns an ``earth`` (ECEF) TF lookup into the geographic position and
+attitude an XTF ping header needs.
+
+The ROS ``earth`` frame is the Earth-Centred Earth-Fixed (ECEF) frame
+(REP-105), so a ``lookup_transform('earth', sensor_frame)`` yields the
+sensor's ECEF position (translation) and its orientation expressed in
+ECEF. XTF wants geographic coordinates (decimal degrees) plus
+heading/pitch/roll relative to local north. This module does that
+conversion with no third-party dependencies (pure ``numpy`` + ``math``),
+so the converter inherits no runtime deps beyond what ``bag_analysis``
+already declares.
+
+All angles are radians inside the functions; the public ping-facing
+helpers return degrees where noted.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+# WGS84 ellipsoid constants.
+_WGS84_A = 6378137.0                     # semi-major axis (m)
+_WGS84_F = 1.0 / 298.257223563           # flattening
+_WGS84_B = _WGS84_A * (1.0 - _WGS84_F)   # semi-minor axis (m)
+_WGS84_E2 = _WGS84_F * (2.0 - _WGS84_F)  # first eccentricity squared
+
+
+def geodetic_to_ecef(lat_deg: float, lon_deg: float, alt_m: float) -> tuple[
+        float, float, float]:
+    """Convert geodetic lat/lon/alt (WGS84) to ECEF X/Y/Z metres."""
+    lat = math.radians(lat_deg)
+    lon = math.radians(lon_deg)
+    sin_lat = math.sin(lat)
+    n = _WGS84_A / math.sqrt(1.0 - _WGS84_E2 * sin_lat * sin_lat)
+    x = (n + alt_m) * math.cos(lat) * math.cos(lon)
+    y = (n + alt_m) * math.cos(lat) * math.sin(lon)
+    z = (n * (1.0 - _WGS84_E2) + alt_m) * sin_lat
+    return x, y, z
+
+
+def ecef_to_geodetic(x: float, y: float, z: float) -> tuple[
+        float, float, float]:
+    """
+    Convert ECEF X/Y/Z metres to geodetic lat/lon (degrees) and alt (m).
+
+    Uses Bowring's iteration, which converges in a few steps for any
+    point on or near the Earth's surface.
+    """
+    lon = math.atan2(y, x)
+    p = math.hypot(x, y)
+    if p < 1e-9:
+        # On the polar axis; latitude is +/-90 deg, longitude undefined.
+        lat = math.copysign(math.pi / 2.0, z)
+        alt = abs(z) - _WGS84_B
+        return math.degrees(lat), math.degrees(lon), alt
+
+    lat = math.atan2(z, p * (1.0 - _WGS84_E2))
+    for _ in range(8):
+        sin_lat = math.sin(lat)
+        n = _WGS84_A / math.sqrt(1.0 - _WGS84_E2 * sin_lat * sin_lat)
+        lat = math.atan2(z + _WGS84_E2 * n * sin_lat, p)
+    sin_lat = math.sin(lat)
+    n = _WGS84_A / math.sqrt(1.0 - _WGS84_E2 * sin_lat * sin_lat)
+    alt = p / math.cos(lat) - n
+    return math.degrees(lat), math.degrees(lon), alt
+
+
+def ecef_to_enu_rotation(lat_deg: float, lon_deg: float) -> np.ndarray:
+    """
+    Return the 3x3 rotation mapping an ECEF vector to local ENU.
+
+    Columns of the result expressed as a matrix multiply: ``v_enu = R @
+    v_ecef``. ENU axes are East, North, Up at the given geodetic point.
+    """
+    lat = math.radians(lat_deg)
+    lon = math.radians(lon_deg)
+    sin_lat, cos_lat = math.sin(lat), math.cos(lat)
+    sin_lon, cos_lon = math.sin(lon), math.cos(lon)
+    return np.array([
+        [-sin_lon, cos_lon, 0.0],
+        [-sin_lat * cos_lon, -sin_lat * sin_lon, cos_lat],
+        [cos_lat * cos_lon, cos_lat * sin_lon, sin_lat],
+    ])
+
+
+# ENU (East, North, Up) -> NED (North, East, Down).
+_ENU_TO_NED = np.array([
+    [0.0, 1.0, 0.0],
+    [1.0, 0.0, 0.0],
+    [0.0, 0.0, -1.0],
+])
+
+
+def quaternion_to_matrix(x: float, y: float, z: float, w: float) -> np.ndarray:
+    """
+    Convert a quaternion (x, y, z, w) to a 3x3 rotation matrix.
+
+    The matrix maps a vector in the rotated (body) frame to the
+    reference frame, matching the tf2 convention where
+    ``p_parent = R @ p_child``.
+    """
+    norm = math.sqrt(x * x + y * y + z * z + w * w)
+    if norm < 1e-12:
+        return np.eye(3)
+    x, y, z, w = x / norm, y / norm, z / norm, w / norm
+    return np.array([
+        [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+        [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+        [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+    ])
+
+
+def matrix_to_heading_pitch_roll(r_body_to_ned: np.ndarray) -> tuple[
+        float, float, float]:
+    """
+    Extract (heading, pitch, roll) in degrees from a body->NED matrix.
+
+    Uses the aerospace ZYX (yaw-pitch-roll) convention. Heading is
+    returned in ``[0, 360)`` degrees clockwise from north; pitch and
+    roll in ``[-180, 180]``.
+    """
+    heading = math.atan2(r_body_to_ned[1, 0], r_body_to_ned[0, 0])
+    pitch = math.atan2(
+        -r_body_to_ned[2, 0],
+        math.hypot(r_body_to_ned[2, 1], r_body_to_ned[2, 2]),
+    )
+    roll = math.atan2(r_body_to_ned[2, 1], r_body_to_ned[2, 2])
+    return math.degrees(heading) % 360.0, math.degrees(pitch), \
+        math.degrees(roll)
+
+
+def ecef_pose_to_geo(
+    translation: tuple[float, float, float],
+    quaternion: tuple[float, float, float, float],
+) -> tuple[float, float, float, float, float, float]:
+    """
+    Convert an ``earth``->sensor TF pose to geographic position + attitude.
+
+    Parameters
+    ----------
+    translation
+        ECEF (x, y, z) of the sensor origin, metres.
+    quaternion
+        Sensor orientation in ECEF as (x, y, z, w), tf2 convention.
+
+    Returns
+    -------
+    tuple
+        ``(lat_deg, lon_deg, alt_m, heading_deg, pitch_deg, roll_deg)``.
+        Heading/pitch/roll are the sensor body axes relative to local
+        NED at the sensor's position.
+
+    """
+    x, y, z = translation
+    lat_deg, lon_deg, alt_m = ecef_to_geodetic(x, y, z)
+    r_body_to_ecef = quaternion_to_matrix(*quaternion)
+    r_ecef_to_enu = ecef_to_enu_rotation(lat_deg, lon_deg)
+    r_body_to_ned = _ENU_TO_NED @ r_ecef_to_enu @ r_body_to_ecef
+    heading, pitch, roll = matrix_to_heading_pitch_roll(r_body_to_ned)
+    return lat_deg, lon_deg, alt_m, heading, pitch, roll

--- a/bag_analysis/bag_analysis/xtf/writer.py
+++ b/bag_analysis/bag_analysis/xtf/writer.py
@@ -205,7 +205,10 @@ class XtfWriter:
         struct.pack_into('<f', buf, 12, float(chan.time_delay_s))
         struct.pack_into('<f', buf, 16, float(chan.time_duration_s))
         struct.pack_into('<f', buf, 20, float(chan.seconds_per_ping))
-        struct.pack_into('<H', buf, 26, int(chan.frequency_hz) & 0xFFFF)
+        # The per-ping Frequency field here is a uint16 (Hz) that cannot
+        # represent sidescan frequencies (e.g. 455 kHz), so it is left 0;
+        # the authoritative per-channel frequency lives in CHANINFO
+        # (a float) written in the file header.
         struct.pack_into('<I', buf, 42, num_samples)              # NumSamples
         return bytes(buf)
 

--- a/bag_analysis/bag_analysis/xtf/writer.py
+++ b/bag_analysis/bag_analysis/xtf/writer.py
@@ -1,0 +1,225 @@
+"""
+Streaming binary writer for XTF (eXtended Triton Format) sidescan files.
+
+XTF is a little-endian binary format: a fixed 1024-byte file header
+(256 bytes of global fields followed by six 128-byte ``CHANINFO``
+blocks), then a stream of ping packets. Each sonar ping packet is a
+256-byte ``XTFPINGHEADER`` followed by, for every channel, a 64-byte
+``XTFPINGCHANHEADER`` and that channel's raw amplitude samples.
+
+This writer targets the common two-channel sidescan layout: channel 0 =
+port, channel 1 = starboard, both 16-bit unsigned samples. It writes the
+header on construction and appends ping packets one at a time, so memory
+stays bounded regardless of bag length.
+
+Field offsets and semantics follow the Triton XTF specification (the
+same layout the ``pyxtf`` reader implements). Only the fields a sidescan
+mosaic actually needs are populated; the remainder are left zero.
+
+References
+----------
+* Triton Imaging XTF File Format specification.
+* https://en.wikipedia.org/wiki/EXtended_Triton_Format
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import datetime as _dt
+import struct
+from typing import BinaryIO
+
+import numpy as np
+
+# --- Constant magic / enum values from the XTF spec ----------------------
+_FILE_FORMAT = 0x7B          # XTFFILEHEADER.FileFormat (123)
+_SYSTEM_TYPE = 1             # generic
+_PING_MAGIC = 0xFACE         # XTFPINGHEADER.MagicNumber
+_HEADER_TYPE_SONAR = 0       # XTFPINGHEADER.HeaderType for sonar pings
+_NAV_UNITS_LATLON = 3        # XTFFILEHEADER.NavUnits: 3 => lat/lon degrees
+_CHAN_TYPE_PORT = 1          # CHANINFO.TypeOfChannel
+_CHAN_TYPE_STBD = 2
+_BYTES_PER_SAMPLE = 2        # 16-bit samples
+
+_FILE_HEADER_LEN = 1024
+_CHAN_INFO_LEN = 128
+_CHAN_INFO_BASE = 256        # first CHANINFO starts here
+_PING_HEADER_LEN = 256
+_PING_CHAN_HEADER_LEN = 64
+
+_SAMPLE_DTYPE = np.dtype('<u2')  # little-endian uint16
+
+
+@dataclass
+class ChannelPing:
+    """One channel's data for a single ping."""
+
+    samples: np.ndarray   # 1-D, will be cast to little-endian uint16
+    slant_range_m: float  # range to the last sample, metres
+    frequency_hz: float = 0.0
+    seconds_per_ping: float = 0.0
+    time_delay_s: float = 0.0   # one-way? -> round-trip time to first sample
+    time_duration_s: float = 0.0
+
+
+class XtfWriter:
+    """Write a two-channel (port/starboard) sidescan XTF file incrementally."""
+
+    def __init__(
+        self,
+        stream: BinaryIO,
+        *,
+        sonar_name: str = 'sidescan',
+        program_name: str = 'bag_to_xtf',
+        note: str = '',
+        port_frequency_hz: float = 0.0,
+        starboard_frequency_hz: float = 0.0,
+    ) -> None:
+        """Open the writer and emit the XTF file header to ``stream``."""
+        self._stream = stream
+        self._ping_count = 0
+        self._write_file_header(
+            sonar_name, program_name, note,
+            port_frequency_hz, starboard_frequency_hz,
+        )
+
+    @property
+    def ping_count(self) -> int:
+        """Return the number of ping packets written so far."""
+        return self._ping_count
+
+    # -- file header ------------------------------------------------------
+    def _write_file_header(
+        self,
+        sonar_name: str,
+        program_name: str,
+        note: str,
+        port_freq: float,
+        stbd_freq: float,
+    ) -> None:
+        """Write the 1024-byte XTF file header and channel-info blocks."""
+        buf = bytearray(_FILE_HEADER_LEN)
+        struct.pack_into('<B', buf, 0, _FILE_FORMAT)
+        struct.pack_into('<B', buf, 1, _SYSTEM_TYPE)
+        _pack_string(buf, 2, program_name, 8)    # RecordingProgramName
+        _pack_string(buf, 10, '1.0', 8)          # RecordingProgramVersion
+        _pack_string(buf, 18, sonar_name, 16)    # SonarName
+        _pack_string(buf, 36, note, 64)          # NoteString
+        struct.pack_into('<H', buf, 164, _NAV_UNITS_LATLON)   # NavUnits
+        struct.pack_into('<H', buf, 166, 2)      # NumberOfSonarChannels
+        # CHANINFO[0] = port, CHANINFO[1] = starboard.
+        self._pack_chan_info(buf, 0, _CHAN_TYPE_PORT, 'PORT', port_freq)
+        self._pack_chan_info(buf, 1, _CHAN_TYPE_STBD, 'STBD', stbd_freq)
+        self._stream.write(buf)
+
+    @staticmethod
+    def _pack_chan_info(
+        buf: bytearray,
+        index: int,
+        type_of_channel: int,
+        name: str,
+        frequency_hz: float,
+    ) -> None:
+        base = _CHAN_INFO_BASE + index * _CHAN_INFO_LEN
+        struct.pack_into('<B', buf, base + 0, type_of_channel)  # TypeOfChannel
+        struct.pack_into('<B', buf, base + 1, index)            # SubChannel
+        struct.pack_into('<H', buf, base + 6, _BYTES_PER_SAMPLE)
+        _pack_string(buf, base + 12, name, 16)                 # ChannelName
+        struct.pack_into('<f', buf, base + 28, 1.0)            # VoltScale
+        struct.pack_into('<f', buf, base + 32, float(frequency_hz))
+
+    # -- ping packets -----------------------------------------------------
+    def write_ping(
+        self,
+        *,
+        time: _dt.datetime,
+        ping_number: int,
+        latitude_deg: float,
+        longitude_deg: float,
+        sensor_depth_m: float,
+        altitude_m: float,
+        heading_deg: float,
+        pitch_deg: float,
+        roll_deg: float,
+        speed_mps: float,
+        sound_velocity_mps: float,
+        port: ChannelPing,
+        starboard: ChannelPing,
+    ) -> None:
+        """Append one two-channel sonar ping packet to the file."""
+        port_bytes = _samples_to_bytes(port.samples)
+        stbd_bytes = _samples_to_bytes(starboard.samples)
+        n_port = len(port_bytes) // _BYTES_PER_SAMPLE
+        n_stbd = len(stbd_bytes) // _BYTES_PER_SAMPLE
+
+        num_bytes_record = (
+            _PING_HEADER_LEN
+            + 2 * _PING_CHAN_HEADER_LEN
+            + len(port_bytes) + len(stbd_bytes)
+        )
+
+        header = bytearray(_PING_HEADER_LEN)
+        struct.pack_into('<H', header, 0, _PING_MAGIC)
+        struct.pack_into('<B', header, 2, _HEADER_TYPE_SONAR)
+        struct.pack_into('<H', header, 4, 2)            # NumChansToFollow
+        struct.pack_into('<I', header, 10, num_bytes_record)
+        struct.pack_into('<H', header, 14, time.year)
+        struct.pack_into('<B', header, 16, time.month)
+        struct.pack_into('<B', header, 17, time.day)
+        struct.pack_into('<B', header, 18, time.hour)
+        struct.pack_into('<B', header, 19, time.minute)
+        struct.pack_into('<B', header, 20, time.second)
+        struct.pack_into('<B', header, 21, time.microsecond // 10000)  # hsec
+        struct.pack_into('<I', header, 28, ping_number & 0xFFFFFFFF)
+        struct.pack_into('<f', header, 32, float(sound_velocity_mps))
+        struct.pack_into('<f', header, 120, float(speed_mps))   # ShipSpeed
+        struct.pack_into('<f', header, 124, float(heading_deg))  # ShipGyro
+        struct.pack_into('<d', header, 128, float(latitude_deg))   # ShipY
+        struct.pack_into('<d', header, 136, float(longitude_deg))  # ShipX
+        struct.pack_into('<f', header, 152, float(speed_mps))   # SensorSpeed
+        struct.pack_into('<d', header, 160, float(latitude_deg))   # SensorY
+        struct.pack_into('<d', header, 168, float(longitude_deg))  # SensorX
+        struct.pack_into('<f', header, 192, float(sensor_depth_m))
+        struct.pack_into('<f', header, 196, float(altitude_m))  # Altitude
+        struct.pack_into('<f', header, 204, float(pitch_deg))
+        struct.pack_into('<f', header, 208, float(roll_deg))
+        struct.pack_into('<f', header, 212, float(heading_deg))
+
+        self._stream.write(header)
+        self._stream.write(
+            self._chan_header(0, n_port, port))
+        self._stream.write(port_bytes)
+        self._stream.write(
+            self._chan_header(1, n_stbd, starboard))
+        self._stream.write(stbd_bytes)
+        self._ping_count += 1
+
+    @staticmethod
+    def _chan_header(
+        channel_number: int, num_samples: int, chan: ChannelPing,
+    ) -> bytes:
+        buf = bytearray(_PING_CHAN_HEADER_LEN)
+        struct.pack_into('<H', buf, 0, channel_number)
+        struct.pack_into('<f', buf, 4, float(chan.slant_range_m))  # SlantRange
+        struct.pack_into('<f', buf, 12, float(chan.time_delay_s))
+        struct.pack_into('<f', buf, 16, float(chan.time_duration_s))
+        struct.pack_into('<f', buf, 20, float(chan.seconds_per_ping))
+        struct.pack_into('<H', buf, 26, int(chan.frequency_hz) & 0xFFFF)
+        struct.pack_into('<I', buf, 42, num_samples)              # NumSamples
+        return bytes(buf)
+
+
+def _samples_to_bytes(samples: np.ndarray) -> bytes:
+    """Cast a 1-D sample array to little-endian uint16 bytes (clipped)."""
+    arr = np.asarray(samples)
+    if arr.ndim != 1:
+        arr = arr.reshape(-1)
+    arr = np.clip(arr, 0, 65535).astype(_SAMPLE_DTYPE, copy=False)
+    return arr.tobytes()
+
+
+def _pack_string(buf: bytearray, offset: int, value: str, length: int) -> None:
+    """Write a fixed-width, NUL-padded ASCII string into ``buf``."""
+    encoded = value.encode('ascii', errors='replace')[:length]
+    buf[offset:offset + len(encoded)] = encoded

--- a/bag_analysis/package.xml
+++ b/bag_analysis/package.xml
@@ -10,6 +10,10 @@
   <depend>rclpy</depend>
   <depend>rosbag2_py</depend>
   <depend>rosidl_runtime_py</depend>
+  <!-- tf2_ros: bag_to_xtf composes earth->sensor offline from the bag's
+       /tf stream to georeference each sidescan ping. -->
+  <depend>tf2_ros</depend>
+  <depend>marine_acoustic_msgs</depend>
 
   <!-- Message packages we have extractors for; types we don't extract
        (tf2_msgs, visualization_msgs, std_msgs/Header, etc.) need to be

--- a/bag_analysis/setup.py
+++ b/bag_analysis/setup.py
@@ -23,6 +23,7 @@ setup(
         'console_scripts': [
             'bag_to_sqlite = bag_analysis.cli.bag_to_sqlite:main',
             'sqlite_to_report = bag_analysis.cli.sqlite_to_report:main',
+            'bag_to_xtf = bag_analysis.cli.bag_to_xtf:main',
         ],
     },
 )

--- a/bag_analysis/test/test_xtf_cli.py
+++ b/bag_analysis/test/test_xtf_cli.py
@@ -7,8 +7,11 @@ age-bounded so a TF gap can't silently stamp a ping with an unrelated
 pose.
 """
 
+import datetime as _dt
+
 from bag_analysis.cli.bag_to_xtf import (
     _lookup_pose,
+    _parse_time,
     _PendingPing,
     _speed_mps,
     _stamp_ns,
@@ -24,6 +27,23 @@ _MAX_AGE_NS = 1_000_000_000  # 1 s
 
 def test_stamp_ns():
     assert _stamp_ns(TimeMsg(sec=12, nanosec=500_000_000)) == 12_500_000_000
+
+
+def test_parse_time_none():
+    assert _parse_time(None) is None
+
+
+def test_parse_time_epoch_seconds():
+    assert _parse_time('100.5') == 100_500_000_000
+
+
+def test_parse_time_iso_utc():
+    # A naive ISO time is read as UTC, so it equals the explicit-Z form.
+    expected = int(
+        _dt.datetime(2026, 6, 15, 16, 26, 49,
+                     tzinfo=_dt.timezone.utc).timestamp() * 1e9)
+    assert _parse_time('2026-06-15T16:26:49') == expected
+    assert _parse_time('2026-06-15T16:26:49Z') == expected
 
 
 def test_speed_mps_from_ecef_displacement():

--- a/bag_analysis/test/test_xtf_cli.py
+++ b/bag_analysis/test/test_xtf_cli.py
@@ -1,0 +1,85 @@
+"""
+Tests for bag_analysis.cli.bag_to_xtf helpers.
+
+Covers the timestamp/speed helpers and the bounded TF lookup, which is
+the safety-critical piece: a fallback to the latest transform must be
+age-bounded so a TF gap can't silently stamp a ping with an unrelated
+pose.
+"""
+
+from bag_analysis.cli.bag_to_xtf import (
+    _lookup_pose,
+    _PendingPing,
+    _speed_mps,
+    _stamp_ns,
+)
+from builtin_interfaces.msg import Time as TimeMsg
+from geometry_msgs.msg import TransformStamped
+import numpy as np
+from rclpy.duration import Duration
+from tf2_ros import Buffer
+
+_MAX_AGE_NS = 1_000_000_000  # 1 s
+
+
+def test_stamp_ns():
+    assert _stamp_ns(TimeMsg(sec=12, nanosec=500_000_000)) == 12_500_000_000
+
+
+def test_speed_mps_from_ecef_displacement():
+    a = _PendingPing(t_ns=0, ecef=np.array([0.0, 0.0, 0.0]))
+    b = _PendingPing(t_ns=2_000_000_000, ecef=np.array([0.0, 0.0, 10.0]))
+    assert _speed_mps(a, b) == 5.0  # 10 m over 2 s
+
+
+def test_speed_mps_zero_dt():
+    a = _PendingPing(t_ns=5, ecef=np.array([0.0, 0.0, 0.0]))
+    b = _PendingPing(t_ns=5, ecef=np.array([1.0, 0.0, 0.0]))
+    assert _speed_mps(a, b) == 0.0
+
+
+def _tf(frame: str, sec: int, x: float, y: float, z: float) -> TransformStamped:
+    tf = TransformStamped()
+    tf.header.stamp = TimeMsg(sec=sec, nanosec=0)
+    tf.header.frame_id = 'earth'
+    tf.child_frame_id = frame
+    tf.transform.translation.x = x
+    tf.transform.translation.y = y
+    tf.transform.translation.z = z
+    tf.transform.rotation.w = 1.0
+    return tf
+
+
+def _buffer() -> Buffer:
+    buf = Buffer(cache_time=Duration(seconds=600))
+    buf.set_transform(_tf('sensor', 10, 1.0, 2.0, 3.0), 'test')
+    return buf
+
+
+def test_lookup_pose_exact():
+    pose, status = _lookup_pose(
+        _buffer(), 'sensor', 'earth', TimeMsg(sec=10, nanosec=0), _MAX_AGE_NS)
+    assert status == 'exact'
+    assert pose[0] == (1.0, 2.0, 3.0)
+
+
+def test_lookup_pose_approx_within_age():
+    pose, status = _lookup_pose(
+        _buffer(), 'sensor', 'earth',
+        TimeMsg(sec=10, nanosec=500_000_000), _MAX_AGE_NS)
+    assert status == 'approx'
+    assert pose is not None
+
+
+def test_lookup_pose_stale_beyond_age():
+    pose, status = _lookup_pose(
+        _buffer(), 'sensor', 'earth', TimeMsg(sec=20, nanosec=0), _MAX_AGE_NS)
+    assert status == 'stale'
+    assert pose is None
+
+
+def test_lookup_pose_missing_frame():
+    pose, status = _lookup_pose(
+        _buffer(), 'ghost', 'earth', TimeMsg(sec=10, nanosec=0), _MAX_AGE_NS)
+    assert status == 'missing'
+    assert pose is None

--- a/bag_analysis/test/test_xtf_geo.py
+++ b/bag_analysis/test/test_xtf_geo.py
@@ -1,0 +1,87 @@
+"""Tests for bag_analysis.xtf.geo WGS84 / attitude helpers."""
+
+import math
+
+from bag_analysis.xtf.geo import (
+    ecef_pose_to_geo,
+    ecef_to_enu_rotation,
+    ecef_to_geodetic,
+    geodetic_to_ecef,
+    matrix_to_heading_pitch_roll,
+)
+import numpy as np
+
+# Lake Massabesic, where the 2026-06-15 sidescan was captured.
+_LAT, _LON, _ALT = 42.990559, -71.392957, 48.5
+
+
+def test_geodetic_ecef_round_trip():
+    x, y, z = geodetic_to_ecef(_LAT, _LON, _ALT)
+    lat, lon, alt = ecef_to_geodetic(x, y, z)
+    assert math.isclose(lat, _LAT, abs_tol=1e-7)
+    assert math.isclose(lon, _LON, abs_tol=1e-7)
+    assert math.isclose(alt, _ALT, abs_tol=1e-3)
+
+
+def test_geodetic_to_ecef_known_origin():
+    # (0, 0, 0) sits on the equator at the prime meridian: +X axis.
+    x, y, z = geodetic_to_ecef(0.0, 0.0, 0.0)
+    assert math.isclose(x, 6378137.0, abs_tol=1e-3)
+    assert math.isclose(y, 0.0, abs_tol=1e-6)
+    assert math.isclose(z, 0.0, abs_tol=1e-6)
+
+
+def test_ecef_to_enu_rotation_at_origin():
+    # At lat=lon=0: ECEF +X->Up, +Y->East, +Z->North.
+    r = ecef_to_enu_rotation(0.0, 0.0)
+    assert np.allclose(r @ np.array([1.0, 0, 0]), [0, 0, 1], atol=1e-9)  # Up
+    assert np.allclose(r @ np.array([0, 1.0, 0]), [1, 0, 0], atol=1e-9)  # East
+    assert np.allclose(r @ np.array([0, 0, 1.0]), [0, 1, 0], atol=1e-9)  # N
+
+
+def test_heading_pitch_roll_from_identity():
+    heading, pitch, roll = matrix_to_heading_pitch_roll(np.eye(3))
+    assert math.isclose(heading, 0.0, abs_tol=1e-9)
+    assert math.isclose(pitch, 0.0, abs_tol=1e-9)
+    assert math.isclose(roll, 0.0, abs_tol=1e-9)
+
+
+def test_heading_pitch_roll_pure_yaw():
+    # 90 deg yaw about NED down axis -> heading 90 (facing east).
+    c, s = math.cos(math.pi / 2), math.sin(math.pi / 2)
+    r = np.array([[c, -s, 0], [s, c, 0], [0, 0, 1.0]])
+    heading, pitch, roll = matrix_to_heading_pitch_roll(r)
+    assert math.isclose(heading, 90.0, abs_tol=1e-6)
+    assert math.isclose(pitch, 0.0, abs_tol=1e-6)
+    assert math.isclose(roll, 0.0, abs_tol=1e-6)
+
+
+def _matrix_to_quaternion(r: np.ndarray):
+    """Convert a rotation matrix to (x, y, z, w) for test construction."""
+    w = math.sqrt(max(0.0, 1.0 + r[0, 0] + r[1, 1] + r[2, 2])) / 2.0
+    x = math.sqrt(max(0.0, 1.0 + r[0, 0] - r[1, 1] - r[2, 2])) / 2.0
+    y = math.sqrt(max(0.0, 1.0 - r[0, 0] + r[1, 1] - r[2, 2])) / 2.0
+    z = math.sqrt(max(0.0, 1.0 - r[0, 0] - r[1, 1] + r[2, 2])) / 2.0
+    x = math.copysign(x, r[2, 1] - r[1, 2])
+    y = math.copysign(y, r[0, 2] - r[2, 0])
+    z = math.copysign(z, r[1, 0] - r[0, 1])
+    return x, y, z, w
+
+
+def test_ecef_pose_to_geo_north_aligned():
+    # Build a sensor whose body axes coincide with local NED (heading 0).
+    # body->ECEF = (ENU->NED @ ECEF->ENU)^T when body->NED is identity.
+    enu_to_ned = np.array([[0, 1.0, 0], [1.0, 0, 0], [0, 0, -1.0]])
+    r_ecef_to_enu = ecef_to_enu_rotation(_LAT, _LON)
+    r_body_to_ecef = (enu_to_ned @ r_ecef_to_enu).T
+    quat = _matrix_to_quaternion(r_body_to_ecef)
+    translation = geodetic_to_ecef(_LAT, _LON, _ALT)
+
+    lat, lon, alt, heading, pitch, roll = ecef_pose_to_geo(translation, quat)
+    assert math.isclose(lat, _LAT, abs_tol=1e-6)
+    assert math.isclose(lon, _LON, abs_tol=1e-6)
+    assert math.isclose(alt, _ALT, abs_tol=1e-2)
+    # Heading is on a circle: 0 and 360 are the same bearing.
+    assert abs((heading + 180.0) % 360.0 - 180.0) < 1e-4
+    assert math.isclose(pitch, 0.0, abs_tol=1e-4)
+    assert math.isclose(roll, 0.0, abs_tol=1e-4)

--- a/bag_analysis/test/test_xtf_writer.py
+++ b/bag_analysis/test/test_xtf_writer.py
@@ -111,6 +111,10 @@ def test_ping_packets_round_trip():
     assert list(first['channels'][0]['samples']) == [10, 20, 30, 40]
     assert list(first['channels'][1]['samples']) == [50, 60, 70, 80]
     assert first['channels'][0]['slant'] == pytest.approx(20.0)
+    # The per-ping Frequency uint16 (offset 26) can't hold sidescan
+    # frequencies, so it is deliberately left 0 rather than truncated.
+    chan0 = 1024 + 256
+    assert struct.unpack_from('<H', data, chan0 + 26)[0] == 0
 
     second = pings[1]
     assert list(second['channels'][0]['samples']) == [11, 21, 31]

--- a/bag_analysis/test/test_xtf_writer.py
+++ b/bag_analysis/test/test_xtf_writer.py
@@ -1,0 +1,159 @@
+"""
+Tests for bag_analysis.xtf.writer.
+
+Validates the written XTF binary by parsing it back with plain ``struct``
+(no third-party dependency), then, if ``pyxtf`` happens to be installed,
+cross-checks that an independent reader agrees on ping count and samples.
+"""
+
+import datetime as _dt
+import io
+import struct
+
+from bag_analysis.xtf.writer import ChannelPing, XtfWriter
+import numpy as np
+import pytest
+
+_FILE_HEADER_LEN = 1024
+_PING_HEADER_LEN = 256
+_PING_CHAN_HEADER_LEN = 64
+
+
+def _chan(values, slant_range=20.0, freq=455000.0):
+    return ChannelPing(
+        samples=np.asarray(values, dtype=np.uint16),
+        slant_range_m=slant_range, frequency_hz=freq,
+        seconds_per_ping=0.08, time_delay_s=0.0002, time_duration_s=0.026)
+
+
+def _write_two_pings() -> bytes:
+    stream = io.BytesIO()
+    writer = XtfWriter(stream, sonar_name='Test Sidescan',
+                       port_frequency_hz=455000.0,
+                       starboard_frequency_hz=455000.0)
+    t = _dt.datetime(2026, 6, 15, 15, 3, 45, 120000, tzinfo=_dt.timezone.utc)
+    writer.write_ping(
+        time=t, ping_number=0, latitude_deg=42.990559,
+        longitude_deg=-71.392957, sensor_depth_m=0.0, altitude_m=3.5,
+        heading_deg=123.4, pitch_deg=1.2, roll_deg=-2.3, speed_mps=1.5,
+        sound_velocity_mps=1500.0,
+        port=_chan([10, 20, 30, 40]), starboard=_chan([50, 60, 70, 80]))
+    writer.write_ping(
+        time=t, ping_number=1, latitude_deg=42.990600,
+        longitude_deg=-71.392900, sensor_depth_m=0.0, altitude_m=3.6,
+        heading_deg=124.0, pitch_deg=1.0, roll_deg=-2.0, speed_mps=1.6,
+        sound_velocity_mps=1500.0,
+        port=_chan([11, 21, 31]), starboard=_chan([51, 61, 71]))
+    assert writer.ping_count == 2
+    return stream.getvalue()
+
+
+def test_file_header_fields():
+    data = _write_two_pings()
+    assert len(data) >= _FILE_HEADER_LEN
+    assert data[0] == 0x7B                                  # FileFormat
+    assert struct.unpack_from('<H', data, 164)[0] == 3      # NavUnits lat/lon
+    assert struct.unpack_from('<H', data, 166)[0] == 2      # NumSonarChannels
+    # CHANINFO[0] = port, CHANINFO[1] = starboard.
+    assert data[256 + 0] == 1                               # port channel
+    assert struct.unpack_from('<H', data, 256 + 6)[0] == 2  # BytesPerSample
+    assert data[384 + 0] == 2                               # stbd channel
+    freq = struct.unpack_from('<f', data, 256 + 32)[0]
+    assert freq == pytest.approx(455000.0)
+
+
+def _parse_pings(data: bytes):
+    """Walk ping packets using NumBytesThisRecord; yield parsed dicts."""
+    offset = _FILE_HEADER_LEN
+    pings = []
+    while offset < len(data):
+        magic = struct.unpack_from('<H', data, offset)[0]
+        assert magic == 0xFACE
+        record_len = struct.unpack_from('<I', data, offset + 10)[0]
+        n_chans = struct.unpack_from('<H', data, offset + 4)[0]
+        ping = {
+            'lat': struct.unpack_from('<d', data, offset + 128)[0],
+            'lon': struct.unpack_from('<d', data, offset + 136)[0],
+            'sensor_lat': struct.unpack_from('<d', data, offset + 160)[0],
+            'altitude': struct.unpack_from('<f', data, offset + 196)[0],
+            'heading': struct.unpack_from('<f', data, offset + 212)[0],
+            'year': struct.unpack_from('<H', data, offset + 14)[0],
+            'channels': [],
+        }
+        pos = offset + _PING_HEADER_LEN
+        for _ in range(n_chans):
+            n_samples = struct.unpack_from('<I', data, pos + 42)[0]
+            slant = struct.unpack_from('<f', data, pos + 4)[0]
+            sample_start = pos + _PING_CHAN_HEADER_LEN
+            samples = np.frombuffer(
+                data, dtype='<u2', count=n_samples, offset=sample_start)
+            ping['channels'].append(
+                {'n': n_samples, 'slant': slant, 'samples': samples})
+            pos = sample_start + n_samples * 2
+        pings.append(ping)
+        offset += record_len
+    return pings
+
+
+def test_ping_packets_round_trip():
+    data = _write_two_pings()
+    pings = _parse_pings(data)
+    assert len(pings) == 2
+
+    first = pings[0]
+    assert first['lat'] == pytest.approx(42.990559)
+    assert first['lon'] == pytest.approx(-71.392957)
+    assert first['sensor_lat'] == pytest.approx(42.990559)
+    assert first['altitude'] == pytest.approx(3.5)
+    assert first['heading'] == pytest.approx(123.4, abs=1e-3)
+    assert first['year'] == 2026
+    assert len(first['channels']) == 2
+    assert list(first['channels'][0]['samples']) == [10, 20, 30, 40]
+    assert list(first['channels'][1]['samples']) == [50, 60, 70, 80]
+    assert first['channels'][0]['slant'] == pytest.approx(20.0)
+
+    second = pings[1]
+    assert list(second['channels'][0]['samples']) == [11, 21, 31]
+    assert list(second['channels'][1]['samples']) == [51, 61, 71]
+
+
+def test_record_length_consumes_exact_file():
+    # Walking by NumBytesThisRecord must land exactly on EOF.
+    data = _write_two_pings()
+    offset = _FILE_HEADER_LEN
+    while offset < len(data):
+        offset += struct.unpack_from('<I', data, offset + 10)[0]
+    assert offset == len(data)
+
+
+def test_clipping_out_of_range_samples():
+    stream = io.BytesIO()
+    writer = XtfWriter(stream)
+    t = _dt.datetime(2026, 6, 15, tzinfo=_dt.timezone.utc)
+    writer.write_ping(
+        time=t, ping_number=0, latitude_deg=0.0, longitude_deg=0.0,
+        sensor_depth_m=0.0, altitude_m=0.0, heading_deg=0.0, pitch_deg=0.0,
+        roll_deg=0.0, speed_mps=0.0, sound_velocity_mps=1500.0,
+        port=ChannelPing(samples=np.array([0, 70000, -5], dtype=np.int64),
+                         slant_range_m=10.0),
+        starboard=ChannelPing(samples=np.array([1, 2, 3], dtype=np.int64),
+                              slant_range_m=10.0))
+    pings = _parse_pings(stream.getvalue())
+    assert list(pings[0]['channels'][0]['samples']) == [0, 65535, 0]
+
+
+def test_pyxtf_cross_check_if_available():
+    pyxtf = pytest.importorskip('pyxtf')
+    import tempfile
+    import os
+    data = _write_two_pings()
+    with tempfile.NamedTemporaryFile(
+            suffix='.xtf', delete=False) as handle:
+        handle.write(data)
+        path = handle.name
+    try:
+        _fh, packets = pyxtf.xtf_read(path)
+        sonar = packets.get(pyxtf.XTFHeaderType.sonar, [])
+        assert len(sonar) == 2
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
## Summary

Adds `bag_to_xtf`, an offline converter in the `bag_analysis` package
that turns recorded Garmin sidescan bags into
[eXtended Triton Format (XTF)](https://en.wikipedia.org/wiki/EXtended_Triton_Format)
files, so captures open in standard survey tools (OpenSideScan and
MB-System on Linux; SonarWiz/Triton on Windows).

## What it does

- Reads the port/starboard `marine_acoustic_msgs/RawSonarImage` channels,
  pairs them per ping, and streams a two-channel (port/starboard) XTF.
- Georeferences each ping by composing the bag's TF tree offline and
  looking up `earth → <ping frame_id>`; since `earth` is ECEF, that
  yields the transducer's true lat/lon plus heading/pitch/roll relative
  to local north. Slant range comes from the ping geometry including the
  `sample0` near-field gate; altitude-above-bottom from `nadir_depth`.
- `--start-time` / `--end-time` (epoch or ISO-8601 UTC) trim a survey to
  its dock-out/dock-in window; TF is still consumed across the whole bag,
  so georeferencing is unaffected.
- Robustness: bounded TF fallback (drops + reports pings whose only
  transform is older than `--max-tf-age`), atomic output (`.partial` +
  rename so a crash leaves no truncated file), non-zero exit when zero
  pings are written, malformed-ping drop, and a per-cause conversion
  report. No third-party runtime deps (ECEF↔geodetic via Bowring).

## Modules

- `xtf/geo.py` — WGS84 ECEF↔geodetic + ECEF-orientation → NED
  heading/pitch/roll.
- `xtf/writer.py` — streaming XTF binary writer (file header + CHANINFO +
  per-ping packets), bounded memory.
- `cli/bag_to_xtf.py` — read/georeference/pair/trim/write orchestration,
  registered as the `bag_to_xtf` console script.

## Testing

69 unit tests pass (incl. ament flake8/pep257): XTF binary validated by
round-trip parse with `struct` (optional `pyxtf` cross-check), the
geodesy/attitude math, the bounded TF lookup (exact/approx/stale/missing),
and time parsing.

Verified end to end on the **2026-06-15 Lake Massabesic survey**: trimmed
the 6 h bag to the underway window (16:26:49–20:56:17 UTC, found via
`/bizzy/odom` speed) → 187,912 pings, 137,183 dock-idle pings dropped,
~1377 × 655 m track, correct absolute positions, per-ping slant ranges
tracking the in-survey range changes. Measured TF-fallback staleness at
~50 ms median (~6 cm along-track at survey speed).

A pre-push dual-lens adversarial review (logic + systemic) was run and its
findings addressed; see `progress.md`.

Closes #45

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
