### PR TITLE
Field import: kongsberg_em_bridge .all rollover prototype (2026-06-16)

### DIFF
--- a/kongsberg_em_bridge/kongsberg_em_bridge/node.py
+++ b/kongsberg_em_bridge/kongsberg_em_bridge/node.py
@@ -20,6 +20,7 @@ import os
 import socket
 import struct
 import threading
+import time
 
 from builtin_interfaces.msg import Time as TimeMsg
 from kongsberg_em_bridge import em_datagrams as em
@@ -27,6 +28,23 @@ from marine_acoustic_msgs.msg import DetectionFlag, PingInfo, SonarDetections
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data
+
+
+def save_rollover_due(elapsed_s, bytes_written, max_seconds, max_bytes):
+    """
+    Return ``(should_roll, reason)`` for a ``.all`` recording segment.
+
+    A trigger arms only when its limit is > 0, so the default (0/0) never rolls.
+    Time and size arm independently; time is reported first when both fire.
+    ``elapsed_s`` may be ``None`` before the segment's open time is known, in
+    which case the time trigger is inert. Pure (no I/O) so it is unit-tested
+    without an rclpy node.
+    """
+    if max_seconds > 0 and elapsed_s is not None and elapsed_s >= max_seconds:
+        return True, 'time'
+    if max_bytes > 0 and bytes_written >= max_bytes:
+        return True, 'size'
+    return False, ''
 
 
 class KongsbergEmBridge(Node):
@@ -47,6 +65,15 @@ class KongsbergEmBridge(Node):
         # disables recording. Each node run writes a fresh timestamped file so
         # restarts never overwrite or interleave prior recordings.
         self.declare_parameter('save_all_dir', '')
+        # PROTOTYPE rollover: split the .all recording into a fresh file once
+        # the current one reaches this many wall-clock seconds and/or bytes.
+        # 0 (default) disables that trigger; the two arm independently, so e.g.
+        # max_seconds=600 + max_bytes=0 gives 10-minute files regardless of
+        # size. NOTE (deferred): split segments do NOT yet re-emit the
+        # installation/runtime/SVP datagrams (e.g. I/73) at their head, so a
+        # mid-stream segment may not load/georeference cleanly in some readers.
+        self.declare_parameter('save_all_max_seconds', 0.0)
+        self.declare_parameter('save_all_max_bytes', 0)
 
         self.frame_id = self.get_parameter('frame_id').value
         self.skip_invalid = bool(self.get_parameter('skip_invalid_beams').value)
@@ -54,8 +81,14 @@ class KongsbergEmBridge(Node):
         self.publisher = self.create_publisher(
             SonarDetections, 'detections', qos_profile_sensor_data)
 
-        self._save_file = self._open_save_file(
-            str(self.get_parameter('save_all_dir').value).strip())
+        self._save_dir = str(self.get_parameter('save_all_dir').value).strip()
+        self._save_max_seconds = float(
+            self.get_parameter('save_all_max_seconds').value)
+        self._save_max_bytes = int(self.get_parameter('save_all_max_bytes').value)
+        # Per-segment rollover bookkeeping (reset by _open_save_file).
+        self._save_started = None     # time.monotonic() when current file opened
+        self._save_bytes = 0          # bytes written to the current segment
+        self._save_file = self._open_save_file(self._save_dir)
         self._save_count = 0
         # Guards _save_file across the recv thread (_record) and the main
         # thread (destroy_node). The thread join in destroy_node uses a
@@ -88,19 +121,37 @@ class KongsbergEmBridge(Node):
         """
         if not save_dir:
             return None
-        stamp = datetime.datetime.now(datetime.timezone.utc).strftime(
-            '%Y%m%d_%H%M%S')
-        path = os.path.join(save_dir, f'm3_{stamp}.all')
         try:
             os.makedirs(save_dir, exist_ok=True)
+            path = self._unique_all_path(save_dir)
             handle = open(path, 'wb')
         except OSError as exc:
             self.get_logger().error(
-                f'could not open .all recording {path}: {exc}; '
+                f'could not open .all recording in {save_dir}: {exc}; '
                 f'continuing without recording')
             return None
+        self._save_started = time.monotonic()
+        self._save_bytes = 0
         self.get_logger().info(f'recording received datagrams to {path}')
         return handle
+
+    @staticmethod
+    def _unique_all_path(save_dir):
+        """
+        Return a fresh ``m3_<UTC>.all`` path in ``save_dir`` that does not exist.
+
+        The base name is second-resolution, so a size-triggered roll inside the
+        same second would collide; a ``_NN`` suffix is appended in that case so
+        the ``'wb'`` open never truncates a just-written segment.
+        """
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+            '%Y%m%d_%H%M%S')
+        path = os.path.join(save_dir, f'm3_{stamp}.all')
+        n = 1
+        while os.path.exists(path):
+            path = os.path.join(save_dir, f'm3_{stamp}_{n:02d}.all')
+            n += 1
+        return path
 
     def _record(self, data):
         """Append one received datagram to the ``.all`` file, if recording."""
@@ -108,9 +159,11 @@ class KongsbergEmBridge(Node):
             if self._save_file is None:
                 return
             try:
-                self._save_file.write(em.frame_all_record(data))
+                framed = em.frame_all_record(data)
+                self._save_file.write(framed)
                 self._save_file.flush()
                 self._save_count += 1
+                self._save_bytes += len(framed)
             except (OSError, ValueError) as exc:
                 # Disable recording on write failure (e.g. disk full, or a
                 # write that lost the close/shutdown race -> "write to closed
@@ -123,6 +176,36 @@ class KongsbergEmBridge(Node):
                 except OSError:
                     pass
                 self._save_file = None
+                return
+            # Roll AFTER a successful write so a completed segment always ends
+            # on a whole datagram boundary (valid .all framing).
+            self._maybe_roll()
+
+    def _maybe_roll(self):
+        """
+        Roll to a fresh ``.all`` segment if a time or size limit is reached.
+
+        Called under ``_save_lock`` with ``_save_file`` open. A reopen failure
+        leaves ``_save_file`` None (recording stops, logged in
+        ``_open_save_file``) while the live bridge keeps running. PROTOTYPE: the
+        new segment does not re-emit installation/runtime datagrams, so a
+        mid-stream file may lack the I/73 record some readers expect.
+        """
+        elapsed = (None if self._save_started is None
+                   else time.monotonic() - self._save_started)
+        should_roll, reason = save_rollover_due(
+            elapsed, self._save_bytes, self._save_max_seconds, self._save_max_bytes)
+        if not should_roll:
+            return
+        self.get_logger().info(
+            f'rolling .all recording ({reason}): completed segment has '
+            f'{self._save_bytes} bytes')
+        try:
+            self._save_file.close()
+        except OSError:
+            pass
+        # _open_save_file resets _save_started/_save_bytes for the new segment.
+        self._save_file = self._open_save_file(self._save_dir)
 
     def destroy_node(self):
         self._running = False
@@ -235,11 +318,14 @@ class KongsbergEmBridge(Node):
 
         self.publisher.publish(msg)
         self._ping_count += 1
-        if self._ping_count % 100 == 1:
-            self.get_logger().info(
-                f'ping {parsed["ping"]}: {len(msg.two_way_travel_times)} detections '
-                f'(of {parsed["nrx"]} beams), c={info.sound_speed:.1f} m/s, '
-                f'f={info.frequency / 1000.0:.0f} kHz')
+        # Decode-health heartbeat, time-throttled rather than every N pings:
+        # at survey ping rates a per-100-ping line prints every few seconds,
+        # which floods the console. ~30 s keeps a liveness signal without spam.
+        self.get_logger().info(
+            f'ping {parsed["ping"]}: {len(msg.two_way_travel_times)} detections '
+            f'(of {parsed["nrx"]} beams), c={info.sound_speed:.1f} m/s, '
+            f'f={info.frequency / 1000.0:.0f} kHz',
+            throttle_duration_sec=30.0)
 
 
 def main(args=None):

--- a/kongsberg_em_bridge/launch/kongsberg_em_bridge.launch.py
+++ b/kongsberg_em_bridge/launch/kongsberg_em_bridge.launch.py
@@ -20,6 +20,14 @@ def generate_launch_description():
             'save_all_dir', default_value='',
             description='Directory to record received datagrams as a timestamped '
                         'Kongsberg .all file; empty disables recording.'),
+        DeclareLaunchArgument(
+            'save_all_max_seconds', default_value='0.0',
+            description='Roll the .all recording to a fresh file after this many '
+                        'wall-clock seconds; 0 disables the time trigger.'),
+        DeclareLaunchArgument(
+            'save_all_max_bytes', default_value='0',
+            description='Roll the .all recording to a fresh file after this many '
+                        'bytes; 0 disables the size trigger.'),
         Node(
             package='kongsberg_em_bridge',
             executable='kongsberg_em_bridge',
@@ -29,6 +37,8 @@ def generate_launch_description():
                 'bind_port': LaunchConfiguration('bind_port'),
                 'frame_id': LaunchConfiguration('frame_id'),
                 'save_all_dir': LaunchConfiguration('save_all_dir'),
+                'save_all_max_seconds': LaunchConfiguration('save_all_max_seconds'),
+                'save_all_max_bytes': LaunchConfiguration('save_all_max_bytes'),
             }],
             output='screen',
         ),

--- a/kongsberg_em_bridge/test/test_save_rollover.py
+++ b/kongsberg_em_bridge/test/test_save_rollover.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+# Hydrographic Center, University of New Hampshire
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Unit tests for the ``.all`` recording rollover prototype (marine_tools).
+
+Covers the pure roll-decision (``save_rollover_due``) and the collision-safe
+segment-path helper (``KongsbergEmBridge._unique_all_path``). Both are exercised
+without an rclpy node so the test needs no ROS graph.
+"""
+
+import os
+
+from kongsberg_em_bridge.node import KongsbergEmBridge, save_rollover_due
+
+
+def test_disabled_by_default_never_rolls():
+    # 0/0 limits: neither trigger arms regardless of elapsed/bytes.
+    assert save_rollover_due(10_000.0, 10_000_000_000, 0.0, 0) == (False, '')
+
+
+def test_time_trigger():
+    assert save_rollover_due(600.0, 0, 600.0, 0) == (True, 'time')
+    assert save_rollover_due(599.9, 0, 600.0, 0) == (False, '')
+
+
+def test_size_trigger():
+    assert save_rollover_due(0.0, 1_000_000_000, 0.0, 1_000_000_000) == (True, 'size')
+    assert save_rollover_due(0.0, 999_999_999, 0.0, 1_000_000_000) == (False, '')
+
+
+def test_time_reported_first_when_both_fire():
+    assert save_rollover_due(700.0, 2_000, 600.0, 1_000) == (True, 'time')
+
+
+def test_unknown_start_time_inert_for_time_trigger():
+    # elapsed None (open time not yet known) must not roll on the time trigger;
+    # the size trigger still works.
+    assert save_rollover_due(None, 0, 600.0, 0) == (False, '')
+    assert save_rollover_due(None, 5_000, 600.0, 1_000) == (True, 'size')
+
+
+def test_unique_all_path_plain_when_absent(tmp_path):
+    path = KongsbergEmBridge._unique_all_path(str(tmp_path))
+    assert path.endswith('.all')
+    assert os.path.dirname(path) == str(tmp_path)
+    assert not os.path.exists(path)
+
+
+def test_unique_all_path_disambiguates_same_second(tmp_path):
+    # Simulate a size-triggered roll inside the same wall-clock second: the
+    # base name already exists, so a _NN suffix must be chosen rather than
+    # returning a path that 'wb' would truncate.
+    first = KongsbergEmBridge._unique_all_path(str(tmp_path))
+    open(first, 'wb').close()
+    second = KongsbergEmBridge._unique_all_path(str(tmp_path))
+    assert second != first
+    assert not os.path.exists(second)


### PR DESCRIPTION
## Field import: kongsberg_em_bridge .all time/size rollover prototype

Imports `81401f0` (field change from the 2026-06-16 Lake Massabesic survey): time/size **rollover** for the M3 `.all` recording — `save_all_max_seconds` / `save_all_max_bytes` params (0=off), rollover on a whole-datagram boundary after a successful write, collision-safe timestamped segments, pure `save_rollover_due()` + 7 tests.

**Pre-review:** 18/18 tests pass, ament flake8/pep257 clean, field-validated (rotated at 200 MB live).

> ⚠️ **NOT production-ready — must-fix before archival use:** split segments don't re-emit the **I/73 install + SVP datagrams** at each segment head, so **mid-stream `.all` files won't georeference in Caris/Qimera/MB-System** (first segment is complete). Add the re-emit (+ test fixture) before relying on rollover for kept data. Deferred during the survey.

Non-diverged (`origin/jazzy` not ahead). Part of rolker/unh_echoboats_project11#289. Closes #51

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
