### PR TITLE
bag_to_xtf: fix SecondsPerPing + add --layout for PINGVerter/PING-Mapper

### DIFF
--- a/bag_analysis/bag_analysis/cli/bag_to_xtf.py
+++ b/bag_analysis/bag_analysis/cli/bag_to_xtf.py
@@ -38,9 +38,9 @@ from tf2_ros import Buffer, TransformException
 from ..reader import iter_messages
 from ..xtf.geo import ecef_pose_to_geo
 from ..xtf.writer import (
+    ChannelPing,
     LAYOUT_PINGMAPPER,
     LAYOUT_STANDARD,
-    ChannelPing,
     XtfWriter,
 )
 
@@ -262,7 +262,8 @@ _MAX_SECONDS_PER_PING = 2.0
 
 
 def _seconds_per_ping(prev: _PendingPing | None, cur: _PendingPing) -> float:
-    """Inter-ping interval (s) for the XTF channel header.
+    """
+    Inter-ping interval (s) for the XTF channel header.
 
     Derived from the time since the previously emitted ping; falls back to a
     nominal value for the first ping and across gaps so the field is always

--- a/bag_analysis/bag_analysis/cli/bag_to_xtf.py
+++ b/bag_analysis/bag_analysis/cli/bag_to_xtf.py
@@ -37,7 +37,12 @@ from tf2_ros import Buffer, TransformException
 
 from ..reader import iter_messages
 from ..xtf.geo import ecef_pose_to_geo
-from ..xtf.writer import ChannelPing, XtfWriter
+from ..xtf.writer import (
+    LAYOUT_PINGMAPPER,
+    LAYOUT_STANDARD,
+    ChannelPing,
+    XtfWriter,
+)
 
 # marine_acoustic_msgs/SonarImageData.dtype -> numpy base type.
 _DTYPE_MAP = {
@@ -121,6 +126,17 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         '--max-pings', type=int, default=None,
         help='Stop after writing this many ping packets (for testing)',
+    )
+    p.add_argument(
+        '--layout', choices=(LAYOUT_STANDARD, LAYOUT_PINGMAPPER),
+        default=LAYOUT_STANDARD,
+        help=(
+            'XTF channel layout. "standard" (default) is the spec-compliant '
+            'interleaved layout read by pyxtf and standard XTF tools. '
+            '"pingmapper" is a non-standard contiguous layout required by '
+            'PINGVerter / PING-Mapper, which misread the standard layout; '
+            'files written this way will mis-decode in standard XTF readers.'
+        ),
     )
     return p
 
@@ -237,6 +253,30 @@ def _speed_mps(a: _PendingPing, b: _PendingPing) -> float:
     return float(np.linalg.norm(a.ecef - b.ecef) / dt)
 
 
+# Nominal inter-ping interval (s) used for the first ping and across gaps,
+# where the real spacing is unavailable or implausible. ~0.1 s is a
+# representative sidescan ping period; any finite positive value works.
+_DEFAULT_SECONDS_PER_PING = 0.1
+# Gaps longer than this are treated as dropouts, not real ping intervals.
+_MAX_SECONDS_PER_PING = 2.0
+
+
+def _seconds_per_ping(prev: _PendingPing | None, cur: _PendingPing) -> float:
+    """Inter-ping interval (s) for the XTF channel header.
+
+    Derived from the time since the previously emitted ping; falls back to a
+    nominal value for the first ping and across gaps so the field is always
+    finite and positive. PINGVerter / PING-Mapper reject SecondsPerPing <= 0
+    (they flag the whole ping as invalid geometry), so 0 must never be written.
+    """
+    if prev is None:
+        return _DEFAULT_SECONDS_PER_PING
+    dt = (cur.t_ns - prev.t_ns) / 1e9
+    if not 0.0 < dt <= _MAX_SECONDS_PER_PING:
+        return _DEFAULT_SECONDS_PER_PING
+    return dt
+
+
 def _convert(args, stream, counts) -> int:
     """Run the read/georeference/pair/write loop; return pings written."""
     buffer = Buffer(cache_time=Duration(seconds=args.tf_cache))
@@ -249,7 +289,8 @@ def _convert(args, stream, counts) -> int:
     start_ns = _parse_time(args.start_time)
     end_ns = _parse_time(args.end_time)
 
-    writer = XtfWriter(stream, sonar_name=args.sonar_name)
+    writer = XtfWriter(
+        stream, sonar_name=args.sonar_name, layout=args.layout)
     pending: dict = {'port': None, 'starboard': None}
     latest_altitude = None
     prev_emitted = None
@@ -257,6 +298,7 @@ def _convert(args, stream, counts) -> int:
     def emit(port: _PendingPing, stbd: _PendingPing) -> None:
         nonlocal prev_emitted
         speed = _speed_mps(prev_emitted, port) if prev_emitted else 0.0
+        seconds_per_ping = _seconds_per_ping(prev_emitted, port)
         if latest_altitude is None:
             counts['no_altitude'] += 1
         writer.write_ping(
@@ -269,11 +311,13 @@ def _convert(args, stream, counts) -> int:
             port=ChannelPing(
                 samples=port.samples, slant_range_m=port.slant_range,
                 frequency_hz=port.frequency, time_delay_s=port.time_delay,
-                time_duration_s=port.time_duration),
+                time_duration_s=port.time_duration,
+                seconds_per_ping=seconds_per_ping),
             starboard=ChannelPing(
                 samples=stbd.samples, slant_range_m=stbd.slant_range,
                 frequency_hz=stbd.frequency, time_delay_s=stbd.time_delay,
-                time_duration_s=stbd.time_duration),
+                time_duration_s=stbd.time_duration,
+                seconds_per_ping=seconds_per_ping),
         )
         counts['paired'] += 1
         prev_emitted = port

--- a/bag_analysis/bag_analysis/xtf/writer.py
+++ b/bag_analysis/bag_analysis/xtf/writer.py
@@ -81,7 +81,8 @@ class XtfWriter:
         starboard_frequency_hz: float = 0.0,
         layout: str = LAYOUT_STANDARD,
     ) -> None:
-        """Open the writer and emit the XTF file header to ``stream``.
+        """
+        Open the writer and emit the XTF file header to ``stream``.
 
         ``layout`` controls the per-ping channel arrangement:
 

--- a/bag_analysis/bag_analysis/xtf/writer.py
+++ b/bag_analysis/bag_analysis/xtf/writer.py
@@ -50,6 +50,10 @@ _PING_CHAN_HEADER_LEN = 64
 
 _SAMPLE_DTYPE = np.dtype('<u2')  # little-endian uint16
 
+# Per-ping channel layouts (see XtfWriter for the trade-off).
+LAYOUT_STANDARD = 'standard'      # interleaved [hdr0][data0][hdr1][data1]
+LAYOUT_PINGMAPPER = 'pingmapper'  # contiguous  [hdr0][hdr1][data0][data1]
+
 
 @dataclass
 class ChannelPing:
@@ -75,9 +79,29 @@ class XtfWriter:
         note: str = '',
         port_frequency_hz: float = 0.0,
         starboard_frequency_hz: float = 0.0,
+        layout: str = LAYOUT_STANDARD,
     ) -> None:
-        """Open the writer and emit the XTF file header to ``stream``."""
+        """Open the writer and emit the XTF file header to ``stream``.
+
+        ``layout`` controls the per-ping channel arrangement:
+
+        * ``LAYOUT_STANDARD`` (default) -- spec-compliant interleaved layout:
+          each XTFPINGCHANHEADER is immediately followed by its own channel's
+          samples (``[hdr0][data0][hdr1][data1]``). This is what the Triton XTF
+          spec and the reference reader (pyxtf) require.
+        * ``LAYOUT_PINGMAPPER`` -- non-standard contiguous layout that groups
+          both channel headers first, then both channels' samples
+          (``[hdr0][hdr1][data0][data1]``). PINGVerter / PING-Mapper assume
+          this arrangement and misread the standard interleaved layout for the
+          second channel; use it only when the output is destined for that
+          toolchain. Standard XTF readers will mis-decode it.
+        """
+        if layout not in (LAYOUT_STANDARD, LAYOUT_PINGMAPPER):
+            raise ValueError(
+                f'unknown layout {layout!r}; expected '
+                f'{LAYOUT_STANDARD!r} or {LAYOUT_PINGMAPPER!r}')
         self._stream = stream
+        self._layout = layout
         self._ping_count = 0
         self._write_file_header(
             sonar_name, program_name, note,
@@ -191,13 +215,22 @@ class XtfWriter:
         struct.pack_into('<f', header, 208, float(roll_deg))
         struct.pack_into('<f', header, 212, float(heading_deg))
 
+        port_header = self._chan_header(0, n_port, port)
+        stbd_header = self._chan_header(1, n_stbd, starboard)
+
         self._stream.write(header)
-        self._stream.write(
-            self._chan_header(0, n_port, port))
-        self._stream.write(port_bytes)
-        self._stream.write(
-            self._chan_header(1, n_stbd, starboard))
-        self._stream.write(stbd_bytes)
+        if self._layout == LAYOUT_PINGMAPPER:
+            # Contiguous: both channel headers, then both channels' samples.
+            self._stream.write(port_header)
+            self._stream.write(stbd_header)
+            self._stream.write(port_bytes)
+            self._stream.write(stbd_bytes)
+        else:
+            # Standard interleaved: each header immediately followed by its data.
+            self._stream.write(port_header)
+            self._stream.write(port_bytes)
+            self._stream.write(stbd_header)
+            self._stream.write(stbd_bytes)
         self._ping_count += 1
 
     @staticmethod

--- a/bag_analysis/test/test_xtf_cli.py
+++ b/bag_analysis/test/test_xtf_cli.py
@@ -10,15 +10,18 @@ pose.
 import datetime as _dt
 
 from bag_analysis.cli.bag_to_xtf import (
+    _DEFAULT_SECONDS_PER_PING,
     _lookup_pose,
     _parse_time,
     _PendingPing,
+    _seconds_per_ping,
     _speed_mps,
     _stamp_ns,
 )
 from builtin_interfaces.msg import Time as TimeMsg
 from geometry_msgs.msg import TransformStamped
 import numpy as np
+import pytest
 from rclpy.duration import Duration
 from tf2_ros import Buffer
 
@@ -56,6 +59,34 @@ def test_speed_mps_zero_dt():
     a = _PendingPing(t_ns=5, ecef=np.array([0.0, 0.0, 0.0]))
     b = _PendingPing(t_ns=5, ecef=np.array([1.0, 0.0, 0.0]))
     assert _speed_mps(a, b) == 0.0
+
+
+def test_seconds_per_ping_first_ping_uses_default():
+    # No previous ping -> nominal value, never 0 (PINGVerter rejects spp <= 0).
+    cur = _PendingPing(t_ns=1_000_000_000)
+    assert _seconds_per_ping(None, cur) == _DEFAULT_SECONDS_PER_PING
+    assert _seconds_per_ping(None, cur) > 0.0
+
+
+def test_seconds_per_ping_uses_interping_interval():
+    prev = _PendingPing(t_ns=1_000_000_000)
+    cur = _PendingPing(t_ns=1_050_000_000)  # 50 ms later
+    assert _seconds_per_ping(prev, cur) == pytest.approx(0.05)
+
+
+def test_seconds_per_ping_gap_falls_back_to_default():
+    prev = _PendingPing(t_ns=1_000_000_000)
+    cur = _PendingPing(t_ns=6_000_000_000)  # 5 s gap (dropout)
+    assert _seconds_per_ping(prev, cur) == _DEFAULT_SECONDS_PER_PING
+
+
+def test_seconds_per_ping_nonincreasing_stamp_falls_back_to_default():
+    # Duplicate / out-of-order stamps must not yield 0 or a negative interval.
+    prev = _PendingPing(t_ns=2_000_000_000)
+    same = _PendingPing(t_ns=2_000_000_000)
+    earlier = _PendingPing(t_ns=1_000_000_000)
+    assert _seconds_per_ping(prev, same) == _DEFAULT_SECONDS_PER_PING
+    assert _seconds_per_ping(prev, earlier) == _DEFAULT_SECONDS_PER_PING
 
 
 def _tf(frame: str, sec: int, x: float, y: float, z: float) -> TransformStamped:

--- a/bag_analysis/test/test_xtf_writer.py
+++ b/bag_analysis/test/test_xtf_writer.py
@@ -11,9 +11,9 @@ import io
 import struct
 
 from bag_analysis.xtf.writer import (
+    ChannelPing,
     LAYOUT_PINGMAPPER,
     LAYOUT_STANDARD,
-    ChannelPing,
     XtfWriter,
 )
 import numpy as np
@@ -146,10 +146,12 @@ def test_port_channel_reversed_starboard_unchanged():
 
 
 def test_seconds_per_ping_written_to_channel_header():
-    """SecondsPerPing must round-trip as finite/positive at channel-header
-    offset 20. PINGVerter rejects SecondsPerPing <= 0 (flags the whole ping as
-    invalid geometry), so a 0 here makes the XTF unreadable -- see marine_tools
-    issue #58."""
+    """
+    Each channel header must carry a finite, positive SecondsPerPing.
+
+    PINGVerter rejects SecondsPerPing <= 0 (it flags the whole ping as invalid
+    geometry), so writing 0 makes the XTF unreadable -- see marine_tools #58.
+    """
     stream = io.BytesIO()
     writer = XtfWriter(stream)
     t = _dt.datetime(2026, 6, 15, tzinfo=_dt.timezone.utc)
@@ -180,8 +182,11 @@ def _write_one_ping(layout, n_port, n_stbd):
 
 
 def test_standard_layout_interleaves_header_and_data():
-    """Standard (spec/pyxtf) layout: [hdr0][data0][hdr1][data1] -- channel 1's
-    header sits AFTER channel 0's header and channel 0's samples."""
+    """
+    Interleaved layout places channel 1's header after channel 0's data.
+
+    Standard / pyxtf layout is [hdr0][data0][hdr1][data1].
+    """
     n = 6
     data = _write_one_ping(LAYOUT_STANDARD, n, n)
     chan0 = _FILE_HEADER_LEN + _PING_HEADER_LEN
@@ -191,8 +196,12 @@ def test_standard_layout_interleaves_header_and_data():
 
 
 def test_pingmapper_layout_groups_headers_then_data():
-    """PINGMapper (contiguous) layout: [hdr0][hdr1][data0][data1] -- channel 1's
-    header immediately follows channel 0's header, with no samples between."""
+    """
+    Contiguous layout places both channel headers before any sample data.
+
+    PINGMapper layout is [hdr0][hdr1][data0][data1], with no samples between
+    the two headers.
+    """
     n = 6
     data = _write_one_ping(LAYOUT_PINGMAPPER, n, n)
     chan0 = _FILE_HEADER_LEN + _PING_HEADER_LEN

--- a/bag_analysis/test/test_xtf_writer.py
+++ b/bag_analysis/test/test_xtf_writer.py
@@ -10,10 +10,16 @@ import datetime as _dt
 import io
 import struct
 
-from bag_analysis.xtf.writer import ChannelPing, XtfWriter
+from bag_analysis.xtf.writer import (
+    LAYOUT_PINGMAPPER,
+    LAYOUT_STANDARD,
+    ChannelPing,
+    XtfWriter,
+)
 import numpy as np
 import pytest
 
+_FILE_HEADER_LEN = 1024
 _FILE_HEADER_LEN = 1024
 _PING_HEADER_LEN = 256
 _PING_CHAN_HEADER_LEN = 64
@@ -84,11 +90,13 @@ def _parse_pings(data: bytes):
         for _ in range(n_chans):
             n_samples = struct.unpack_from('<I', data, pos + 42)[0]
             slant = struct.unpack_from('<f', data, pos + 4)[0]
+            seconds_per_ping = struct.unpack_from('<f', data, pos + 20)[0]
             sample_start = pos + _PING_CHAN_HEADER_LEN
             samples = np.frombuffer(
                 data, dtype='<u2', count=n_samples, offset=sample_start)
             ping['channels'].append(
-                {'n': n_samples, 'slant': slant, 'samples': samples})
+                {'n': n_samples, 'slant': slant,
+                 'seconds_per_ping': seconds_per_ping, 'samples': samples})
             pos = sample_start + n_samples * 2
         pings.append(ping)
         offset += record_len
@@ -135,6 +143,72 @@ def test_port_channel_reversed_starboard_unchanged():
     ping = _parse_pings(stream.getvalue())[0]
     assert list(ping['channels'][0]['samples']) == [5, 4, 3, 2, 1]  # port flipped
     assert list(ping['channels'][1]['samples']) == [1, 2, 3, 4, 5]  # stbd as-is
+
+
+def test_seconds_per_ping_written_to_channel_header():
+    """SecondsPerPing must round-trip as finite/positive at channel-header
+    offset 20. PINGVerter rejects SecondsPerPing <= 0 (flags the whole ping as
+    invalid geometry), so a 0 here makes the XTF unreadable -- see marine_tools
+    issue #58."""
+    stream = io.BytesIO()
+    writer = XtfWriter(stream)
+    t = _dt.datetime(2026, 6, 15, tzinfo=_dt.timezone.utc)
+    writer.write_ping(
+        time=t, ping_number=0, latitude_deg=0.0, longitude_deg=0.0,
+        sensor_depth_m=0.0, altitude_m=0.0, heading_deg=0.0, pitch_deg=0.0,
+        roll_deg=0.0, speed_mps=0.0, sound_velocity_mps=1500.0,
+        port=_chan([1, 2, 3, 4]), starboard=_chan([5, 6, 7, 8]))
+    ping = _parse_pings(stream.getvalue())[0]
+    for chan in ping['channels']:
+        assert chan['seconds_per_ping'] > 0.0
+        assert chan['seconds_per_ping'] == pytest.approx(0.08)  # from _chan()
+
+
+def _write_one_ping(layout, n_port, n_stbd):
+    """Write a single ping in ``layout`` and return the raw file bytes."""
+    stream = io.BytesIO()
+    kwargs = {} if layout is None else {'layout': layout}
+    writer = XtfWriter(stream, **kwargs)
+    t = _dt.datetime(2026, 6, 15, tzinfo=_dt.timezone.utc)
+    writer.write_ping(
+        time=t, ping_number=0, latitude_deg=0.0, longitude_deg=0.0,
+        sensor_depth_m=0.0, altitude_m=0.0, heading_deg=0.0, pitch_deg=0.0,
+        roll_deg=0.0, speed_mps=0.0, sound_velocity_mps=1500.0,
+        port=_chan(list(range(1, n_port + 1))),
+        starboard=_chan(list(range(1, n_stbd + 1))))
+    return stream.getvalue()
+
+
+def test_standard_layout_interleaves_header_and_data():
+    """Standard (spec/pyxtf) layout: [hdr0][data0][hdr1][data1] -- channel 1's
+    header sits AFTER channel 0's header and channel 0's samples."""
+    n = 6
+    data = _write_one_ping(LAYOUT_STANDARD, n, n)
+    chan0 = _FILE_HEADER_LEN + _PING_HEADER_LEN
+    chan1 = chan0 + _PING_CHAN_HEADER_LEN + n * 2  # past chan0 hdr + chan0 data
+    assert struct.unpack_from('<H', data, chan1)[0] == 1       # ChannelNumber
+    assert struct.unpack_from('<I', data, chan1 + 42)[0] == n  # NumSamples
+
+
+def test_pingmapper_layout_groups_headers_then_data():
+    """PINGMapper (contiguous) layout: [hdr0][hdr1][data0][data1] -- channel 1's
+    header immediately follows channel 0's header, with no samples between."""
+    n = 6
+    data = _write_one_ping(LAYOUT_PINGMAPPER, n, n)
+    chan0 = _FILE_HEADER_LEN + _PING_HEADER_LEN
+    chan1 = chan0 + _PING_CHAN_HEADER_LEN  # immediately after chan0 header
+    assert struct.unpack_from('<H', data, chan1)[0] == 1       # ChannelNumber
+    assert struct.unpack_from('<I', data, chan1 + 42)[0] == n  # NumSamples
+
+
+def test_default_layout_is_standard():
+    assert _write_one_ping(None, 4, 4) == _write_one_ping(LAYOUT_STANDARD, 4, 4)
+    assert _write_one_ping(None, 4, 4) != _write_one_ping(LAYOUT_PINGMAPPER, 4, 4)
+
+
+def test_unknown_layout_rejected():
+    with pytest.raises(ValueError):
+        XtfWriter(io.BytesIO(), layout='bogus')
 
 
 def test_record_length_consumes_exact_file():


### PR DESCRIPTION
Makes `bag_to_xtf` output ingestible by PINGVerter / PING-Mapper (umbrella #171),
fixing two defects found while bringing the bag → XTF → PING-Mapper pipeline up.

Closes #58

## 1. `SecondsPerPing` was always 0
`_convert`'s `emit()` built each `ChannelPing` without `seconds_per_ping`, so it
kept the dataclass default `0.0`, written into channel-header offset 20.
PINGVerter flags any ping with `seconds_per_ping <= 1e-6` as invalid geometry and
then crashes (`IntCastingNaNError`) casting the all-NaN metadata column to int.
Now computed from the inter-ping interval (Δt since the previous emitted ping),
with a nominal fallback for the first ping and across gaps.

## 2. `--layout {standard,pingmapper}`
The XTF spec and the reference reader **pyxtf** place each `XTFPINGCHANHEADER`
immediately before its own samples — interleaved `[hdr0][data0][hdr1][data1]`.
PINGVerter instead assumes contiguous headers `[hdr0][hdr1][data0][data1]`
(`xtf_class.py:386,402`) and misreads the second channel.

- **`standard`** (default) — spec-compliant interleaved layout; read correctly by
  pyxtf and standard XTF tools (SonarWiz/CARIS/Qimera).
- **`pingmapper`** — non-standard contiguous layout PINGVerter needs; standard
  readers mis-decode it, so it is opt-in and documented as such.

## Verification
| Layout | pyxtf | PINGVerter |
|--------|-------|------------|
| `standard` (default) | ✅ 2 ch, n=2035, SlantRange=35 | ❌ (expected) |
| `pingmapper` | ❌ (expected) | ✅ 400 rows, beams 2/3, valid pixM/spp |

Spec confirmation: pyxtf's read loop (header-then-its-samples per channel) and the
Triton XTF spec text ("samples following the XTFPINGCHANHEADER").

## Tests
`_seconds_per_ping` interval + fallback cases; `SecondsPerPing` channel-header
round-trip; byte-position assertions for both layouts; default-is-standard;
unknown-layout-rejected. `ament_flake8` + `ament_pep257` clean.

## Note
PINGVerter's inability to read standard interleaved XTF is an upstream bug; an
upstream report is deferred (the `--layout pingmapper` shim unblocks us meanwhile).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
