### PR TITLE
Field import: marine_tools contacts_to_geojson exporter (+ tests)

### DIFF
--- a/bag_analysis/bag_analysis/cli/contacts_to_geojson.py
+++ b/bag_analysis/bag_analysis/cli/contacts_to_geojson.py
@@ -1,4 +1,5 @@
-"""Export operator-marked sonar contacts (and deployment log entries) to GeoJSON.
+r"""
+Export operator-marked sonar contacts (+ deployment log entries) to GeoJSON.
 
 Two feature sources land in one ``FeatureCollection`` so they overlay on the
 same map (QGIS, web, CAMP):
@@ -46,9 +47,9 @@ from rclpy.duration import Duration
 import rclpy.time
 from tf2_ros import Buffer
 
+from .bag_to_xtf import _lookup_pose, _stamp_ns
 from ..reader import iter_messages
 from ..xtf.geo import ecef_pose_to_geo
-from .bag_to_xtf import _lookup_pose, _stamp_ns
 
 _DEFAULT_CONTACTS = '/operator/sonar_waterfall/contacts'
 _DEFAULT_TRACK_FRAME = 'bizzy/base_link'

--- a/bag_analysis/bag_analysis/cli/contacts_to_geojson.py
+++ b/bag_analysis/bag_analysis/cli/contacts_to_geojson.py
@@ -1,0 +1,235 @@
+"""Export operator-marked sonar contacts (and deployment log entries) to GeoJSON.
+
+Two feature sources land in one ``FeatureCollection`` so they overlay on the
+same map (QGIS, web, CAMP):
+
+* **contacts** — ``marine_interfaces/msg/Contact`` from the operator waterfall
+  (default topic ``/operator/sonar_waterfall/contacts``). Each contact already
+  carries a ``geo_pose`` (WGS84 lat/lon/alt) filled in by the waterfall viewer,
+  so it becomes a ``Point`` directly — no TF needed.
+
+* **log entries** — timestamped lines from a deployment markdown log
+  (``**<ts>** — <text>``, the format the ``dlog`` helper writes). These are
+  *text*, not inherently spatial, so each is georeferenced to the boat's
+  position at the entry's timestamp by composing the bag's TF tree offline
+  (``earth`` → ``--track-frame``) — the same offline-TF approach
+  ``bag_to_xtf`` uses. Operators often write a log entry right when they mark a
+  waterfall contact, so placing both on the track makes them directly
+  comparable. An entry that can't be georeferenced (outside the bag's TF span,
+  or no transform) is still emitted, with ``"geometry": null`` and a
+  ``geo_status`` property, so nothing is silently dropped.
+
+GeoJSON has no native time type, so timestamps live in ``properties`` as
+ISO-8601 (``time``) plus epoch seconds (``t_epoch``). Coordinates are
+``[lon, lat]`` (+ ``alt`` when available) in WGS84 per RFC 7946.
+
+Usage::
+
+    ros2 run bag_analysis contacts_to_geojson \\
+        --bag ~/data/logs/operator/2026-06-29/bags/operator_2026-06-29T09.28.14 \\
+        --log .../docs/logs/2026/2026-06-29_salmon_logs.md \\
+        --output ~/share/contacts/2026-06-29.geojson
+
+``--log`` is optional; omit it to export contacts only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+from pathlib import Path
+import re
+import sys
+
+from rclpy.duration import Duration
+import rclpy.time
+from tf2_ros import Buffer
+
+from ..reader import iter_messages
+from ..xtf.geo import ecef_pose_to_geo
+from .bag_to_xtf import _lookup_pose, _stamp_ns
+
+_DEFAULT_CONTACTS = '/operator/sonar_waterfall/contacts'
+_DEFAULT_TRACK_FRAME = 'bizzy/base_link'
+_DEFAULT_EARTH_FRAME = 'earth'
+_NS_PER_S = 1_000_000_000
+
+# A deployment-log entry written by dlog.sh:  **2026-06-29 10:30 -04:00** — text
+# Seconds are optional (dlog writes minute precision); the offset may carry a
+# colon (``-04:00``) or not (``-0400``). The separator is an em dash or hyphen.
+_LOG_ENTRY_RE = re.compile(
+    r'^\*\*\s*'
+    r'(?P<ts>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?\s*[+-]\d{2}:?\d{2})'
+    r'\s*\*\*\s*[—-]+\s*'
+    r'(?P<text>.*\S)\s*$'
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description='Export operator sonar contacts (+ georeferenced log '
+                    'entries) from a rosbag2 to GeoJSON.')
+    p.add_argument('--bag', required=True, type=Path,
+                   help='rosbag2 directory (the one with metadata.yaml)')
+    p.add_argument('--output', required=True, type=Path,
+                   help='Output .geojson path')
+    p.add_argument('--log', type=Path, default=None,
+                   help='Deployment markdown log to georeference and include')
+    p.add_argument('--contacts-topic', default=_DEFAULT_CONTACTS)
+    p.add_argument('--track-frame', default=_DEFAULT_TRACK_FRAME,
+                   help='Boat frame georeferenced against --earth-frame for '
+                        'log entries (default: %(default)s)')
+    p.add_argument('--earth-frame', default=_DEFAULT_EARTH_FRAME,
+                   help='ECEF root frame (default: %(default)s)')
+    p.add_argument('--max-tf-age', type=float, default=5.0,
+                   help='Max age (s) of a fallback "latest" TF for a log '
+                        'entry before it is marked stale (default: %(default)s)')
+    p.add_argument('--tf-cache', type=float, default=6.0 * 3600.0,
+                   help='TF buffer cache length (s); must span the bag so log '
+                        'entries anywhere in it resolve (default: %(default)s)')
+    return p
+
+
+def _parse_log_ts(ts: str) -> _dt.datetime | None:
+    """Parse a dlog timestamp string to an aware datetime, or None."""
+    ts = ts.strip().replace('T', ' ')
+    for fmt in ('%Y-%m-%d %H:%M:%S %z', '%Y-%m-%d %H:%M %z'):
+        try:
+            return _dt.datetime.strptime(ts, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _iso(epoch_s: float) -> str:
+    return _dt.datetime.fromtimestamp(
+        epoch_s, tz=_dt.timezone.utc).isoformat()
+
+
+def _contact_feature(msg, bag_t_ns: int) -> dict:
+    """Build a Point Feature from a marine_interfaces/msg/Contact."""
+    gp = msg.geo_pose.position
+    coords = [float(gp.longitude), float(gp.latitude)]
+    # Only carry altitude when it is finite and meaningful.
+    if gp.altitude == gp.altitude:  # not NaN
+        coords.append(float(gp.altitude))
+
+    stamp_ns = _stamp_ns(msg.header.stamp) or bag_t_ns
+    classification = [
+        getattr(c, 'description', None) or getattr(c, 'classification', '')
+        for c in msg.classification
+    ]
+    props = {
+        'feature_type': 'contact',
+        'id': msg.id,
+        'source': msg.source,
+        'existence_probability': float(msg.existence_probability),
+        'classification': [c for c in classification if c],
+        'status': int(msg.status),
+        'origin_kind': int(msg.origin_kind),
+        'note': msg.note,
+        'frame_id': msg.header.frame_id,
+        'shape_type': int(msg.shape.type),
+        'dim_x_m': float(msg.shape.dimensions.x),
+        'dim_y_m': float(msg.shape.dimensions.y),
+        'dim_z_m': float(msg.shape.dimensions.z),
+        'time': _iso(stamp_ns / 1e9),
+        't_epoch': stamp_ns / 1e9,
+    }
+    return {
+        'type': 'Feature',
+        'geometry': {'type': 'Point', 'coordinates': coords},
+        'properties': props,
+    }
+
+
+def _read_log_entries(path: Path) -> list[tuple[int, str]]:
+    """Parse (epoch_ns, text) tuples from a dlog-format markdown log."""
+    entries = []
+    for line in path.read_text().splitlines():
+        m = _LOG_ENTRY_RE.match(line)
+        if not m:
+            continue
+        dt = _parse_log_ts(m.group('ts'))
+        if dt is None:
+            continue
+        entries.append((int(dt.timestamp() * 1e9), m.group('text')))
+    return entries
+
+
+def _log_feature(t_ns: int, text: str, buffer: Buffer, args,
+                 max_tf_age_ns: int) -> dict:
+    """Georeference one log entry against earth->track_frame at its time."""
+    stamp = rclpy.time.Time(nanoseconds=t_ns).to_msg()
+    pose, status = _lookup_pose(
+        buffer, args.track_frame, args.earth_frame, stamp, max_tf_age_ns)
+    geometry = None
+    if pose is not None:
+        lat, lon, _alt, _hdg, _pitch, _roll = ecef_pose_to_geo(pose[0], pose[1])
+        geometry = {'type': 'Point', 'coordinates': [lon, lat]}
+    return {
+        'type': 'Feature',
+        'geometry': geometry,
+        'properties': {
+            'feature_type': 'log_entry',
+            'text': text,
+            'geo_status': status,   # exact | approx | stale | missing
+            'time': _iso(t_ns / 1e9),
+            't_epoch': t_ns / 1e9,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.bag.exists():
+        print(f'bag not found: {args.bag}', file=sys.stderr)
+        return 2
+
+    want_track = args.log is not None
+    buffer = Buffer(cache_time=Duration(seconds=args.tf_cache))
+    topics = [args.contacts_topic]
+    if want_track:
+        topics += ['/tf', '/tf_static']
+
+    contacts: list[dict] = []
+    for topic, msg, t_ns in iter_messages(args.bag, topics=topics):
+        if topic == '/tf':
+            for tr in msg.transforms:
+                buffer.set_transform(tr, 'contacts_to_geojson')
+        elif topic == '/tf_static':
+            for tr in msg.transforms:
+                buffer.set_transform_static(tr, 'contacts_to_geojson')
+        elif topic == args.contacts_topic:
+            contacts.append(_contact_feature(msg, t_ns))
+
+    features = list(contacts)
+    log_stats = {'exact': 0, 'approx': 0, 'stale': 0, 'missing': 0}
+    if want_track:
+        max_tf_age_ns = int(args.max_tf_age * _NS_PER_S)
+        for t_ns, text in _read_log_entries(args.log):
+            feat = _log_feature(t_ns, text, buffer, args, max_tf_age_ns)
+            log_stats[feat['properties']['geo_status']] += 1
+            features.append(feat)
+
+    features.sort(key=lambda f: f['properties']['t_epoch'])
+    collection = {'type': 'FeatureCollection', 'features': features}
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    partial = args.output.with_name(args.output.name + '.partial')
+    partial.write_text(json.dumps(collection, indent=2))
+    partial.replace(args.output)
+
+    n_log = sum(log_stats.values())
+    print(f'wrote {len(contacts)} contacts'
+          + (f' + {n_log} log entries '
+             f'({log_stats["exact"]} located, {log_stats["approx"]} approx, '
+             f'{log_stats["stale"]} stale, {log_stats["missing"]} unlocated)'
+             if want_track else '')
+          + f' -> {args.output}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bag_analysis/setup.py
+++ b/bag_analysis/setup.py
@@ -24,6 +24,7 @@ setup(
             'bag_to_sqlite = bag_analysis.cli.bag_to_sqlite:main',
             'sqlite_to_report = bag_analysis.cli.sqlite_to_report:main',
             'bag_to_xtf = bag_analysis.cli.bag_to_xtf:main',
+            'contacts_to_geojson = bag_analysis.cli.contacts_to_geojson:main',
         ],
     },
 )

--- a/bag_analysis/test/test_contacts_to_geojson.py
+++ b/bag_analysis/test/test_contacts_to_geojson.py
@@ -1,0 +1,146 @@
+"""
+Tests for the contacts_to_geojson exporter's pure helpers.
+
+The georeferencing path (offline TF over a rosbag2) needs a bag and is
+exercised in the field; these unit tests cover the bag-free logic: dlog
+timestamp parsing, log-line extraction, the ISO-8601 helper, and the
+Contact -> GeoJSON Feature shaping.
+"""
+
+import datetime as _dt
+import math
+from types import SimpleNamespace
+
+from bag_analysis.cli.contacts_to_geojson import (
+    _contact_feature,
+    _iso,
+    _parse_log_ts,
+    _read_log_entries,
+)
+
+
+def test_parse_log_ts_with_seconds():
+    dt = _parse_log_ts('2026-06-29 10:30:45 -04:00')
+    assert dt is not None
+    # -04:00 means 14:30:45 UTC.
+    assert dt.astimezone(_dt.timezone.utc).hour == 14
+    assert dt.utcoffset() == _dt.timedelta(hours=-4)
+
+
+def test_parse_log_ts_minute_precision():
+    dt = _parse_log_ts('2026-06-29 10:30 -04:00')
+    assert dt is not None
+    assert dt.second == 0
+    assert dt.astimezone(_dt.timezone.utc).hour == 14
+
+
+def test_parse_log_ts_offset_without_colon():
+    with_colon = _parse_log_ts('2026-06-29 10:30 -04:00')
+    without = _parse_log_ts('2026-06-29 10:30 -0400')
+    assert with_colon is not None and without is not None
+    assert with_colon.timestamp() == without.timestamp()
+
+
+def test_parse_log_ts_t_separator():
+    dt = _parse_log_ts('2026-06-29T10:30 -04:00')
+    assert dt is not None
+    assert dt.astimezone(_dt.timezone.utc).hour == 14
+
+
+def test_parse_log_ts_rejects_garbage():
+    assert _parse_log_ts('not a timestamp') is None
+    assert _parse_log_ts('2026-06-29 10:30') is None  # no offset
+
+
+def test_iso_epoch_zero():
+    assert _iso(0) == '1970-01-01T00:00:00+00:00'
+
+
+def test_iso_known_instant():
+    # 2026-06-29 14:30:00 UTC.
+    epoch = _dt.datetime(
+        2026, 6, 29, 14, 30, tzinfo=_dt.timezone.utc).timestamp()
+    assert _iso(epoch) == '2026-06-29T14:30:00+00:00'
+
+
+def test_read_log_entries(tmp_path):
+    log = tmp_path / 'log.md'
+    log.write_text(
+        '# 2026-06-29 — gabby log\n'
+        '\n'
+        'Deployment issue: pending\n'
+        '**2026-06-29 10:30 -04:00** — em-dash entry\n'
+        '**2026-06-29 10:31:05 -0400** - hyphen entry, seconds\n'
+        'a plain narrative line, not an entry\n'
+        '**bogus-ts** — malformed timestamp, skipped\n'
+    )
+    entries = _read_log_entries(log)
+    assert len(entries) == 2
+    (t0, text0), (t1, text1) = entries
+    assert text0 == 'em-dash entry'
+    assert text1 == 'hyphen entry, seconds'
+    # File order preserved; second entry is 65 s after the first.
+    assert t1 > t0
+    assert (t1 - t0) == 65 * 1_000_000_000
+
+
+def test_read_log_entries_empty(tmp_path):
+    log = tmp_path / 'empty.md'
+    log.write_text('# header only\n\nno entries here\n')
+    assert _read_log_entries(log) == []
+
+
+def _make_contact(lon, lat, alt, *, sec=0, nanosec=0):
+    return SimpleNamespace(
+        geo_pose=SimpleNamespace(
+            position=SimpleNamespace(
+                longitude=lon, latitude=lat, altitude=alt)),
+        header=SimpleNamespace(
+            stamp=SimpleNamespace(sec=sec, nanosec=nanosec),
+            frame_id='sonar_waterfall'),
+        id='contact-7',
+        source='operator',
+        existence_probability=0.8,
+        classification=[
+            SimpleNamespace(description='rock'),
+            SimpleNamespace(description=''),
+        ],
+        status=2,
+        origin_kind=1,
+        note='marked at survey line 3',
+        shape=SimpleNamespace(
+            type=1,
+            dimensions=SimpleNamespace(x=1.5, y=2.0, z=0.5)),
+    )
+
+
+def test_contact_feature_basic_shaping():
+    msg = _make_contact(-71.38, 42.97, 48.5, sec=100, nanosec=0)
+    feat = _contact_feature(msg, bag_t_ns=999)
+    assert feat['type'] == 'Feature'
+    assert feat['geometry']['type'] == 'Point'
+    # GeoJSON is [lon, lat, alt].
+    assert feat['geometry']['coordinates'] == [-71.38, 42.97, 48.5]
+    props = feat['properties']
+    assert props['feature_type'] == 'contact'
+    assert props['id'] == 'contact-7'
+    assert props['status'] == 2
+    assert props['note'] == 'marked at survey line 3'
+    assert props['classification'] == ['rock']  # empty entry filtered out
+    assert props['dim_x_m'] == 1.5
+    # header stamp (sec=100) wins over the bag time.
+    assert props['t_epoch'] == 100.0
+
+
+def test_contact_feature_omits_nan_altitude():
+    msg = _make_contact(-71.38, 42.97, float('nan'))
+    feat = _contact_feature(msg, bag_t_ns=0)
+    assert feat['geometry']['coordinates'] == [-71.38, 42.97]
+    assert len(feat['geometry']['coordinates']) == 2
+
+
+def test_contact_feature_falls_back_to_bag_time():
+    # Zero header stamp -> _stamp_ns returns 0 (falsy) -> bag time used.
+    msg = _make_contact(-71.38, 42.97, 1.0, sec=0, nanosec=0)
+    feat = _contact_feature(msg, bag_t_ns=5_000_000_000)
+    assert math.isclose(feat['properties']['t_epoch'], 5.0)


### PR DESCRIPTION
## Field import: `contacts_to_geojson` exporter + tests

Imports field commit `40b6bea` (a self-labeled prototype, pushed via gitcloud)
and adds the unit tests + lint fixes that make it merge-ready.

### What the exporter does

`ros2 run bag_analysis contacts_to_geojson` exports operator-marked sonar
contacts (`marine_interfaces/msg/Contact` on `/operator/sonar_waterfall/contacts`)
to a GeoJSON `FeatureCollection`. With `--log`, it also parses `dlog`-format
deployment-log entries and georeferences each to boat position at its timestamp
via offline TF (`earth`→`--track-frame`, reusing `bag_to_xtf`), keeping
unlocatable entries with `null` geometry + a `geo_status` so nothing is dropped.
Field-validated end-to-end on the 2026-06-29 operator bag (86 contacts + 16 log
entries → 102 features).

### Added in this PR (beyond the field commit)

- **Unit tests** (`test/test_contacts_to_geojson.py`, 12 cases) for the bag-free
  logic — the field log listed "add unit tests" as an explicit wrap-up follow-up:
  - `_parse_log_ts` — seconds-optional, `-04:00`/`-0400` offset, `T` separator,
    tz→UTC, garbage rejection
  - `_read_log_entries` — em-dash/hyphen separators, non-entry + malformed-ts
    skipping, ordering
  - `_iso` — epoch→ISO-8601 UTC
  - `_contact_feature` — `[lon, lat, alt]` coords, NaN-altitude omission,
    property mapping, empty-classification filtering, header-stamp vs bag-time
    fallback
- **Lint fixes** to the imported prototype so the package's ament `pep257` +
  `flake8` gate (never run on the field side) stays green: `r"""` + second-line
  docstring summary (D213/D301) and relative-import ordering (I100).

The georeferencing path (needs a bag + TF) stays covered by the field
end-to-end validation; the unit tests target the deterministic helpers.

`colcon`/pytest: 91 passed, 1 skipped (pre-existing). Field SHA `40b6bea`
preserved (fast-forward import).

Closes #65

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
